### PR TITLE
Configure Pod Limit per node

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -45,4 +45,11 @@ parameters:
 
     nodeGroups: {}
 
-    kubeletConfigs: {}
+    kubeletConfigs:
+      workers:
+        machineConfigPoolSelector:
+          matchExpressions:
+            key: pools.operator.machineconfiguration.openshift.io/worker
+            operator: Exists
+        kubeletConfig:
+          maxPods: 110

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -44,3 +44,5 @@ parameters:
                   name: worker-user-data
 
     nodeGroups: {}
+
+    kubeletConfigs: {}

--- a/class/openshift4-nodes.yml
+++ b/class/openshift4-nodes.yml
@@ -7,5 +7,6 @@ parameters:
         output_path: apps/
       - input_paths:
           - openshift4-nodes/component/main.jsonnet
+          - openshift4-nodes/component/kubelet.jsonnet
         input_type: jsonnet
         output_path: openshift4-nodes/

--- a/component/common.libsonnet
+++ b/component/common.libsonnet
@@ -1,0 +1,12 @@
+local kap = import 'lib/kapitan.libjsonnet';
+local kube = import 'lib/kube.libjsonnet';
+local inv = kap.inventory();
+local params = inv.parameters.control_api;
+
+{
+  DefaultLabels: {
+    'app.kubernetes.io/name': 'openshift4-nodes',
+    'app.kubernetes.io/component': 'openshift4-nodes',
+    'app.kubernetes.io/managed-by': 'commodore',
+  },
+}

--- a/component/kubelet.jsonnet
+++ b/component/kubelet.jsonnet
@@ -1,0 +1,24 @@
+local common = import 'common.libsonnet';
+local com = import 'lib/commodore.libjsonnet';
+local kap = import 'lib/kapitan.libjsonnet';
+local kube = import 'lib/kube.libjsonnet';
+local inv = kap.inventory();
+
+local params = inv.parameters.openshift4_nodes;
+
+local kubeletConfigs = [
+  kube._Object('machineconfiguration.openshift.io/v1', 'KubeletConfig', nodeGroup) {
+    metadata+: {
+      labels+: common.DefaultLabels,
+    },
+    spec: params.kubeletConfigs[nodeGroup] {
+      assert !std.objectHas(self.kubeletConfig, 'maxPods') || self.kubeletConfig.maxPods <= 110 : 'kubeletConfig.maxPods cannot be greater than 110',
+    },
+  }
+  for nodeGroup in std.objectFields(params.kubeletConfigs)
+  if params.kubeletConfigs[nodeGroup] != null
+];
+
+{
+  [if std.length(kubeletConfigs) > 0 then '10_kubeletconfigs']: kubeletConfigs,
+}

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -134,6 +134,23 @@ This gives you the full control over the resulting MachineSet.
 Values given here will be merged with precedence with the defaults configured in <<defaultSpec>>.
 The values can be everything that's accepted in the `spec` field of a `machinesets.machine.openshift.io` object.
 
+== `kubeletConfigs`
+
+[horizontal]
+type:: dict
+default:: See `class/defaults.yml`
+
+This parameter accepts a key-value dict where the values are of kind `machineconfiguration.openshift.io/v1/KubeletConfig`.
+The keys are resulting `metadata.name` and the values reflect the `.spec` field of `KubeletConfig`.
+
+[WARNING]
+Please refer to the upstream version of the relevant kubelet for the valid values of these fields.
+Invalid values of the kubelet configuration fields may render cluster nodes unusable.
+
+See https://github.com/kubernetes/kubelet/blob/master/config/v1beta1/types.go[supported configuration fields upstream] (choose matching release branch for versioned options)
+
+See also: https://docs.openshift.com/container-platform/4.9/nodes/nodes/nodes-nodes-managing-max-pods.html[Managing the maximum number of pods per node]
+
 == Example
 
 [source,yaml]
@@ -160,4 +177,13 @@ availabilityZones:
 - europe-west6-a
 - europe-west6-b
 - europe-west6-c
+
+kubeletConfigs:
+  workers:
+    machineConfigPoolSelector:
+      matchExpressions:
+        key: pools.operator.machineconfiguration.openshift.io/worker
+        operator: Exists
+    kubeletConfig:
+      maxPods: 100
 ----

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -147,6 +147,8 @@ The keys are resulting `metadata.name` and the values reflect the `.spec` field 
 Please refer to the upstream version of the relevant kubelet for the valid values of these fields.
 Invalid values of the kubelet configuration fields may render cluster nodes unusable.
 
+[IMPORTANT]
+The component will fail to comile if the configuration field `maxPods` is set to a value larger than 110.
 See https://github.com/kubernetes/kubelet/blob/master/config/v1beta1/types.go[supported configuration fields upstream] (choose matching release branch for versioned options)
 
 See also: https://docs.openshift.com/container-platform/4.9/nodes/nodes/nodes-nodes-managing-max-pods.html[Managing the maximum number of pods per node]

--- a/tests/golden/defaults/openshift4-nodes/openshift4-nodes/10_kubeletconfigs.yaml
+++ b/tests/golden/defaults/openshift4-nodes/openshift4-nodes/10_kubeletconfigs.yaml
@@ -1,0 +1,17 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: openshift4-nodes
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: openshift4-nodes
+    name: workers
+  name: workers
+spec:
+  kubeletConfig:
+    maxPods: 110
+  machineConfigPoolSelector:
+    matchExpressions:
+      key: pools.operator.machineconfiguration.openshift.io/worker
+      operator: Exists


### PR DESCRIPTION
* Supports managing `KubeletConfig`s
* Configures a pod limit of 110 per node using `KubeletConfig`

NOTE: rolling this out may trigger kubelet restarts on all workers but not necessarily restart the workers.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.


<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
