### PR TITLE
Use `parameters.facts.cloud` instead of deprecated `parameters.cloud.provider`

### DIFF
--- a/component/machine-sets.jsonnet
+++ b/component/machine-sets.jsonnet
@@ -8,7 +8,7 @@ local params = inv.parameters.openshift4_nodes;
 local machineSet = function(name, set)
   local role = if std.objectHas(set, 'role') then set.role else name;
   kube._Object('machine.openshift.io/v1beta1', 'MachineSet', name)
-  + { spec+: params.defaultSpecs[inv.parameters.cloud.provider] }
+  + { spec+: params.defaultSpecs[inv.parameters.facts.cloud] }
   + {
     metadata+: {
       labels+: {


### PR DESCRIPTION
See https://syn.tools/commodore/reference/deprecation-notices.html#_v0_3_0

Fixes #9

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
