### PR TITLE
Fix cloud region reclass reference

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -34,7 +34,7 @@ parameters:
                   - network: ${openshift4_nodes:infrastructureID}-network
                     subnetwork: ${openshift4_nodes:infrastructureID}-worker-subnet
                 projectID: ${openshift4_nodes:projectName}
-                region: ${cloud:region}
+                region: ${facts:region}
                 serviceAccounts:
                   - email: ${openshift4_nodes:infrastructureID}-w@${openshift4_nodes:projectName}.iam.gserviceaccount.com
                     scopes:


### PR DESCRIPTION
We've deprecated `cloud.region` a while ago




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
