### PR TITLE
Only render GCP-specific fields when cloud is GCP

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,6 +33,7 @@ jobs:
       matrix:
         instance:
           - defaults
+          - gcp
           - maxpods
           - syn-monitoring
     defaults:
@@ -50,6 +51,7 @@ jobs:
       matrix:
         instance:
           - defaults
+          - gcp
           - maxpods
           - syn-monitoring
     defaults:

--- a/.sync.yml
+++ b/.sync.yml
@@ -6,6 +6,7 @@
     key: instance
     entries:
       - defaults
+      - gcp
       - maxpods
       - syn-monitoring
 

--- a/Makefile.vars.mk
+++ b/Makefile.vars.mk
@@ -49,4 +49,4 @@ KUBENT_IMAGE    ?= docker.io/projectsyn/kubent:latest
 KUBENT_DOCKER   ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) --entrypoint=/app/kubent $(KUBENT_IMAGE)
 
 instance ?= defaults
-test_instances = tests/defaults.yml tests/maxpods.yml tests/syn-monitoring.yml
+test_instances = tests/defaults.yml tests/gcp.yml tests/maxpods.yml tests/syn-monitoring.yml

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -23,6 +23,11 @@ The first item of this list will also be used to place a MachineSet without an e
 It's suggested to define its values higher up the config hierarchy.
 Most probably the one of the cloud region.
 
+[NOTE]
+====
+This is currently only supported on GCP.
+====
+
 == `defaultSpecs`
 
 [horizontal]
@@ -81,6 +86,15 @@ Each set of machines has the values described below.
 
 === `instanceType`
 
+[horizontal]
+type:: string
+default:: null
+
+[NOTE]
+====
+This is currently only supported on GCP.
+====
+
 === `multiAz`
 
 [horizontal]
@@ -94,6 +108,11 @@ The replicas of the generated MachineSets will be calculated.
 The `replicas` given will be divided by the cont of zones in `availabilityZones` rounded up.
 
 See also https://github.com/appuio/component-openshift4-nodes/issues/3[Effective replica count of multi zone machines can be higher than the requested one]
+
+[NOTE]
+====
+This is currently only supported on GCP.
+====
 
 === `replicas`
 

--- a/tests/gcp.yml
+++ b/tests/gcp.yml
@@ -1,0 +1,28 @@
+# Parameters
+parameters:
+  facts:
+    cloud: gcp
+  openshift4_nodes:
+    projectName: cluster-test
+    infrastructureID: infra-id
+
+    availabilityZones:
+      - europe-west6-a
+      - europe-west6-b
+      - europe-west6-c
+
+    nodeGroups:
+      infra:
+        instanceType: n1-standard-8
+        multiAz: true
+        replicas: 3
+      worker:
+        instanceType: n1-standard-8
+        replicas: 3
+        spec:
+          deletePolicy: Oldest
+          template:
+            spec:
+              metadata:
+                labels:
+                  foo: bar

--- a/tests/golden/gcp/openshift4-nodes/openshift4-nodes/10_kubeletconfigs.yaml
+++ b/tests/golden/gcp/openshift4-nodes/openshift4-nodes/10_kubeletconfigs.yaml
@@ -1,0 +1,17 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: openshift4-nodes
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: openshift4-nodes
+    name: workers
+  name: workers
+spec:
+  kubeletConfig:
+    maxPods: 110
+  machineConfigPoolSelector:
+    matchExpressions:
+      - key: pools.operator.machineconfiguration.openshift.io/worker
+        operator: Exists

--- a/tests/golden/gcp/openshift4-nodes/openshift4-nodes/debug.yaml
+++ b/tests/golden/gcp/openshift4-nodes/openshift4-nodes/debug.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/node-selector: ''
+    scheduler.alpha.kubernetes.io/defaultTolerations: '[{"operator":"Exists"}]'
+  labels:
+    name: syn-debug-nodes
+  name: syn-debug-nodes

--- a/tests/golden/gcp/openshift4-nodes/openshift4-nodes/machineset-infra-a.yaml
+++ b/tests/golden/gcp/openshift4-nodes/openshift4-nodes/machineset-infra-a.yaml
@@ -1,0 +1,60 @@
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+metadata:
+  annotations: {}
+  labels:
+    machine.openshift.io/cluster-api-cluster: infra-id
+    name: infra-a
+  name: infra-a
+  namespace: openshift-machine-api
+spec:
+  deletePolicy: Oldest
+  replicas: 1
+  selector:
+    matchLabels:
+      machine.openshift.io/cluster-api-cluster: infra-id
+      machine.openshift.io/cluster-api-machineset: infra-a
+  template:
+    metadata:
+      labels:
+        machine.openshift.io/cluster-api-cluster: infra-id
+        machine.openshift.io/cluster-api-machine-role: infra-a
+        machine.openshift.io/cluster-api-machine-type: infra-a
+        machine.openshift.io/cluster-api-machineset: infra-a
+    spec:
+      metadata:
+        labels:
+          node-role.kubernetes.io/infra-a: ''
+          node-role.kubernetes.io/worker: ''
+      providerSpec:
+        value:
+          apiVersion: gcpprovider.openshift.io/v1beta1
+          canIPForward: false
+          credentialsSecret:
+            name: gcp-cloud-credentials
+          deletionProtection: false
+          disks:
+            - autoDelete: true
+              boot: true
+              image: infra-id-rhcos-image
+              labels: null
+              sizeGb: 128
+              type: pd-ssd
+          kind: GCPMachineProviderSpec
+          machineType: n1-standard-8
+          metadata:
+            creationTimestamp: null
+          networkInterfaces:
+            - network: infra-id-network
+              subnetwork: infra-id-worker-subnet
+          projectID: cluster-test
+          region: rma1
+          serviceAccounts:
+            - email: infra-id-w@cluster-test.iam.gserviceaccount.com
+              scopes:
+                - https://www.googleapis.com/auth/cloud-platform
+          tags:
+            - infra-id-worker
+          userDataSecret:
+            name: worker-user-data
+          zone: europe-west6-a

--- a/tests/golden/gcp/openshift4-nodes/openshift4-nodes/machineset-infra-b.yaml
+++ b/tests/golden/gcp/openshift4-nodes/openshift4-nodes/machineset-infra-b.yaml
@@ -1,0 +1,60 @@
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+metadata:
+  annotations: {}
+  labels:
+    machine.openshift.io/cluster-api-cluster: infra-id
+    name: infra-b
+  name: infra-b
+  namespace: openshift-machine-api
+spec:
+  deletePolicy: Oldest
+  replicas: 1
+  selector:
+    matchLabels:
+      machine.openshift.io/cluster-api-cluster: infra-id
+      machine.openshift.io/cluster-api-machineset: infra-b
+  template:
+    metadata:
+      labels:
+        machine.openshift.io/cluster-api-cluster: infra-id
+        machine.openshift.io/cluster-api-machine-role: infra-b
+        machine.openshift.io/cluster-api-machine-type: infra-b
+        machine.openshift.io/cluster-api-machineset: infra-b
+    spec:
+      metadata:
+        labels:
+          node-role.kubernetes.io/infra-b: ''
+          node-role.kubernetes.io/worker: ''
+      providerSpec:
+        value:
+          apiVersion: gcpprovider.openshift.io/v1beta1
+          canIPForward: false
+          credentialsSecret:
+            name: gcp-cloud-credentials
+          deletionProtection: false
+          disks:
+            - autoDelete: true
+              boot: true
+              image: infra-id-rhcos-image
+              labels: null
+              sizeGb: 128
+              type: pd-ssd
+          kind: GCPMachineProviderSpec
+          machineType: n1-standard-8
+          metadata:
+            creationTimestamp: null
+          networkInterfaces:
+            - network: infra-id-network
+              subnetwork: infra-id-worker-subnet
+          projectID: cluster-test
+          region: rma1
+          serviceAccounts:
+            - email: infra-id-w@cluster-test.iam.gserviceaccount.com
+              scopes:
+                - https://www.googleapis.com/auth/cloud-platform
+          tags:
+            - infra-id-worker
+          userDataSecret:
+            name: worker-user-data
+          zone: europe-west6-b

--- a/tests/golden/gcp/openshift4-nodes/openshift4-nodes/machineset-infra-c.yaml
+++ b/tests/golden/gcp/openshift4-nodes/openshift4-nodes/machineset-infra-c.yaml
@@ -1,0 +1,60 @@
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+metadata:
+  annotations: {}
+  labels:
+    machine.openshift.io/cluster-api-cluster: infra-id
+    name: infra-c
+  name: infra-c
+  namespace: openshift-machine-api
+spec:
+  deletePolicy: Oldest
+  replicas: 1
+  selector:
+    matchLabels:
+      machine.openshift.io/cluster-api-cluster: infra-id
+      machine.openshift.io/cluster-api-machineset: infra-c
+  template:
+    metadata:
+      labels:
+        machine.openshift.io/cluster-api-cluster: infra-id
+        machine.openshift.io/cluster-api-machine-role: infra-c
+        machine.openshift.io/cluster-api-machine-type: infra-c
+        machine.openshift.io/cluster-api-machineset: infra-c
+    spec:
+      metadata:
+        labels:
+          node-role.kubernetes.io/infra-c: ''
+          node-role.kubernetes.io/worker: ''
+      providerSpec:
+        value:
+          apiVersion: gcpprovider.openshift.io/v1beta1
+          canIPForward: false
+          credentialsSecret:
+            name: gcp-cloud-credentials
+          deletionProtection: false
+          disks:
+            - autoDelete: true
+              boot: true
+              image: infra-id-rhcos-image
+              labels: null
+              sizeGb: 128
+              type: pd-ssd
+          kind: GCPMachineProviderSpec
+          machineType: n1-standard-8
+          metadata:
+            creationTimestamp: null
+          networkInterfaces:
+            - network: infra-id-network
+              subnetwork: infra-id-worker-subnet
+          projectID: cluster-test
+          region: rma1
+          serviceAccounts:
+            - email: infra-id-w@cluster-test.iam.gserviceaccount.com
+              scopes:
+                - https://www.googleapis.com/auth/cloud-platform
+          tags:
+            - infra-id-worker
+          userDataSecret:
+            name: worker-user-data
+          zone: europe-west6-c

--- a/tests/golden/gcp/openshift4-nodes/openshift4-nodes/machineset-worker.yaml
+++ b/tests/golden/gcp/openshift4-nodes/openshift4-nodes/machineset-worker.yaml
@@ -1,0 +1,60 @@
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+metadata:
+  annotations: {}
+  labels:
+    machine.openshift.io/cluster-api-cluster: infra-id
+    name: worker
+  name: worker
+  namespace: openshift-machine-api
+spec:
+  deletePolicy: Oldest
+  replicas: 3
+  selector:
+    matchLabels:
+      machine.openshift.io/cluster-api-cluster: infra-id
+      machine.openshift.io/cluster-api-machineset: worker
+  template:
+    metadata:
+      labels:
+        machine.openshift.io/cluster-api-cluster: infra-id
+        machine.openshift.io/cluster-api-machine-role: worker
+        machine.openshift.io/cluster-api-machine-type: worker
+        machine.openshift.io/cluster-api-machineset: worker
+    spec:
+      metadata:
+        labels:
+          foo: bar
+          node-role.kubernetes.io/worker: ''
+      providerSpec:
+        value:
+          apiVersion: gcpprovider.openshift.io/v1beta1
+          canIPForward: false
+          credentialsSecret:
+            name: gcp-cloud-credentials
+          deletionProtection: false
+          disks:
+            - autoDelete: true
+              boot: true
+              image: infra-id-rhcos-image
+              labels: null
+              sizeGb: 128
+              type: pd-ssd
+          kind: GCPMachineProviderSpec
+          machineType: n1-standard-8
+          metadata:
+            creationTimestamp: null
+          networkInterfaces:
+            - network: infra-id-network
+              subnetwork: infra-id-worker-subnet
+          projectID: cluster-test
+          region: rma1
+          serviceAccounts:
+            - email: infra-id-w@cluster-test.iam.gserviceaccount.com
+              scopes:
+                - https://www.googleapis.com/auth/cloud-platform
+          tags:
+            - infra-id-worker
+          userDataSecret:
+            name: worker-user-data
+          zone: europe-west6-a


### PR DESCRIPTION
The GCP-specific fields are not supported by ProviderSpecs like
`awsproviderconfig.openshift.io/v1beta1` or `vsphereprovider.openshift.io/v1beta1`.
Rendering them into the ProviderSpec by default makes the MachineSet
part of this component incompatible with any other ProviderSpec than `gcpprovider.openshift.io/v1beta1`.

Fixes #15

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.