### PR TITLE
Add support for annotations on MachineSets

### DIFF
--- a/component/machine-sets.jsonnet
+++ b/component/machine-sets.jsonnet
@@ -13,6 +13,7 @@ local machineSet = function(name, set)
   + { spec+: params.defaultSpecs[inv.parameters.facts.cloud] }
   + {
     metadata+: {
+      annotations+: com.getValueOrDefault(set, 'annotations', {}),
       labels+: {
         'machine.openshift.io/cluster-api-cluster': params.infrastructureID,
       },

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -84,6 +84,14 @@ It's centered around the MachineSet CRD but also takes care of some additional a
 The top level key is the name of each set of machines.
 Each set of machines has the values described below.
 
+=== `annotations`
+
+[horizontal]
+type:: dictionary
+default:: {}
+
+The annotations to add to the MachineSet.
+
 === `instanceType`
 
 [horizontal]

--- a/tests/gcp.yml
+++ b/tests/gcp.yml
@@ -23,6 +23,8 @@ parameters:
                 value:
                   deletionProtection: true
       worker:
+        annotations:
+          appuio.ch/egress-cidrs: 10.0.0.0/24
         instanceType: n1-standard-8
         replicas: 3
         spec:

--- a/tests/golden/gcp/openshift4-nodes/openshift4-nodes/machineset-worker.yaml
+++ b/tests/golden/gcp/openshift4-nodes/openshift4-nodes/machineset-worker.yaml
@@ -1,7 +1,8 @@
 apiVersion: machine.openshift.io/v1beta1
 kind: MachineSet
 metadata:
-  annotations: {}
+  annotations:
+    appuio.ch/egress-cidrs: 10.0.0.0/24
   labels:
     machine.openshift.io/cluster-api-cluster: infra-id
     name: worker


### PR DESCRIPTION
This allows the configuration of custom annotations on MachineSets which
are used by operators like the [OpenShift MachineSet EgressCIDR operator](https://github.com/appuio/openshift-machineset-egress-cidr-operator).

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.