### PR TITLE
Add support for inline file contents in machine configs

### DIFF
--- a/component/machine-configs.jsonnet
+++ b/component/machine-configs.jsonnet
@@ -16,7 +16,63 @@ local MachineConfig(name) = kube._Object('machineconfiguration.openshift.io/v1',
   },
 };
 
-local machineConfigs = com.generateResources(mergedConfigs, MachineConfig);
+local machineConfigs = [
+  if std.objectHas(mc.spec.config, 'storage') &&
+     std.objectHas(mc.spec.config.storage, 'files') then
+    local inline_files = std.filter(
+      function(f) std.objectHas(f.contents, 'inline'),
+      mc.spec.config.storage.files
+    );
+    mc {
+      metadata+: {
+        annotations+: {
+          [
+          // generate a valid annotation key. Maximum length of the key name (after the /) is 63, cf.
+          // https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set
+          local fname =
+            // annotation keys only support characters `[a-zA-Z0-9_-]`, so we
+            // drop the first `/` and transform all remaining `/` in the path
+            // to `-`.
+            local sanitized = std.strReplace(
+              std.lstripChars(f.path, '/'), '/', '-'
+            );
+            // if the file path is too long, we remove the first section,
+            // since there's a lower chance that two suffices collide than
+            // two prefixes. In most cases, we won't be managing files with a
+            // >63 character path anyway.
+            local len = std.length(sanitized);
+            local start = std.max(len - 63, 0);
+            std.substr(sanitized, start, len);
+          'inline-contents.machineconfig.syn.tools/%s' % fname
+          ]: f.contents.inline
+          for f in inline_files
+        },
+      },
+      spec+: {
+        config+: {
+          storage+: {
+            files: [
+              if std.objectHas(f.contents, 'inline') then
+                f {
+                  contents+: {
+                    inline:: null,
+                    source:
+                      'data:text/plain;encoding=utf-8;base64,%s' %
+                      std.base64(f.contents.inline),
+                  },
+                }
+              else
+                f
+              for f in super.files
+            ],
+          },
+        },
+      },
+    }
+  else
+    mc
+  for mc in com.generateResources(mergedConfigs, MachineConfig)
+];
 {
   [if std.length(machineConfigs) > 0 then '10_machineconfigs']: machineConfigs,
 }

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -276,6 +276,90 @@ machineConfigs:
                 - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAID9BWBmqreqpn7cF9klFEeLrg/NWk3UAyvx7gj/cVFQn
 ----
 
+We add special support for defining file contents in the hierarchy with key `storage.files.X.source.inline` which isn't part of the Ignition spec.
+
+.Inline file contents example (custom `chrony.conf`)
+[source,yaml]
+----
+machineConfigs:
+  worker-chrony-custom:
+    metadata:
+      labels:
+        machineconfiguration.openshift.io/role: worker
+    spec:
+      config:
+        ignition:
+          version: 3.2.0
+        storage:
+          files:
+            - path: /etc/chrony.conf
+              mode: 0644
+              overwrite: true
+              contents:
+                # The contents of `inline` get rendered as
+                # `source: 'data:text/plain;encoding=utf-8;base64,<inline|base64>'`
+                inline: |
+                  # Use ch.pool.ntp.org
+                  pool ch.pool.ntp.org iburst
+                  # Rest is copied from the default config
+                  driftfile /var/lib/chrony/drift
+                  makestep 1.0 3
+                  rtcsync
+                  keyfile /etc/chrony.keys
+                  leapsectz right/UTC
+                  logdir /var/log/chrony
+----
+
+The resulting machine config for this example looks as follows:
+
+[source,yaml]
+----
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  annotations: <1>
+    inline-contents.machineconfig.syn.tools/etc-chrony.conf: '# Use ch.pool.ntp.org
+
+      pool ch.pool.ntp.org iburst
+
+      # Rest is copied from the default config
+
+      driftfile /var/lib/chrony/drift
+
+      makestep 1.0 3
+
+      rtcsync
+
+      keyfile /etc/chrony.keys
+
+      leapsectz right/UTC
+
+      logdir /var/log/chrony
+
+      '
+  labels:
+    app.kubernetes.io/component: openshift4-nodes
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: openshift4-nodes
+    machineconfiguration.openshift.io/role: worker
+    name: 99x-worker-chrony-custom
+  name: 99x-worker-chrony-custom
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    storage:
+      files:
+        - contents:
+            source: data:text/plain;encoding=utf-8;base64,IyBVc2UgY2gucG9vbC5udHAub3JnCnBvb2wgY2gucG9vbC5udHAub3JnIGlidXJzdAojIFJlc3QgaXMgY29waWVkIGZyb20gdGhlIGRlZmF1bHQgY29uZmlnCmRyaWZ0ZmlsZSAvdmFyL2xpYi9jaHJvbnkvZHJpZnQKbWFrZXN0ZXAgMS4wIDMKcnRjc3luYwprZXlmaWxlIC9ldGMvY2hyb255LmtleXMKbGVhcHNlY3R6IHJpZ2h0L1VUQwpsb2dkaXIgL3Zhci9sb2cvY2hyb255Cg== <2>
+          mode: 420
+          overwrite: true
+          path: /etc/chrony.conf
+----
+<1> The original inline file contents are added as an annotation to the resulting machine config object.
+<2> The actual entry in the files list in the Ignition config is encoded with base64 and added as a data scheme value (`data:text/plain;encoding=utf-8;base64,...`) in the `contents.source` field.
+See the https://coreos.github.io/ignition/configuration-v3_2/[Ignition spec] for more details on supported ways to specify file contents.
+
 [NOTE]
 ====
 Keep in mind that machine config objects are evaluated in order of their name.

--- a/tests/golden/machineconfig/openshift4-nodes/openshift4-nodes/10_machineconfigs.yaml
+++ b/tests/golden/machineconfig/openshift4-nodes/openshift4-nodes/10_machineconfigs.yaml
@@ -43,6 +43,48 @@ spec:
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
+  annotations:
+    inline-contents.machineconfig.syn.tools/etc-chrony.conf: '# Use ch.pool.ntp.org
+
+      pool ch.pool.ntp.org iburst
+
+      # Rest is copied from the default config
+
+      driftfile /var/lib/chrony/drift
+
+      makestep 1.0 3
+
+      rtcsync
+
+      keyfile /etc/chrony.keys
+
+      leapsectz right/UTC
+
+      logdir /var/log/chrony
+
+      '
+  labels:
+    app.kubernetes.io/component: openshift4-nodes
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: openshift4-nodes
+    machineconfiguration.openshift.io/role: worker
+    name: 99x-worker-chrony-custom
+  name: 99x-worker-chrony-custom
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    storage:
+      files:
+        - contents:
+            source: data:text/plain;encoding=utf-8;base64,IyBVc2UgY2gucG9vbC5udHAub3JnCnBvb2wgY2gucG9vbC5udHAub3JnIGlidXJzdAojIFJlc3QgaXMgY29waWVkIGZyb20gdGhlIGRlZmF1bHQgY29uZmlnCmRyaWZ0ZmlsZSAvdmFyL2xpYi9jaHJvbnkvZHJpZnQKbWFrZXN0ZXAgMS4wIDMKcnRjc3luYwprZXlmaWxlIC9ldGMvY2hyb255LmtleXMKbGVhcHNlY3R6IHJpZ2h0L1VUQwpsb2dkaXIgL3Zhci9sb2cvY2hyb255Cg==
+          mode: 420
+          overwrite: true
+          path: /etc/chrony.conf
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
   annotations: {}
   labels:
     app.kubernetes.io/component: openshift4-nodes

--- a/tests/machineconfig.yml
+++ b/tests/machineconfig.yml
@@ -62,3 +62,28 @@ parameters:
                 - name: core
                   sshAuthorizedKeys:
                     - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAID9BWBmqreqpn7cF9klFEeLrg/NWk3UAyvx7gj/cVFQn
+      worker-chrony-custom:
+        metadata:
+          labels:
+            machineconfiguration.openshift.io/role: worker
+        spec:
+          config:
+            ignition:
+              version: 3.2.0
+            storage:
+              files:
+                - path: /etc/chrony.conf
+                  mode: 0644
+                  overwrite: true
+                  contents:
+                    # Inline gets rendered as `source: 'data:text/plain;encoding=utf-8;base64,<contents|base64>'`
+                    inline: |
+                      # Use ch.pool.ntp.org
+                      pool ch.pool.ntp.org iburst
+                      # Rest is copied from the default config
+                      driftfile /var/lib/chrony/drift
+                      makestep 1.0 3
+                      rtcsync
+                      keyfile /etc/chrony.keys
+                      leapsectz right/UTC
+                      logdir /var/log/chrony


### PR DESCRIPTION
We implement support for key `contents.inline` for entries in Ignition parameter `storage.files`. This key doesn't exist upstream. We base64-encode the contents of the key and emit the base64-encoded contents as

```
source: data:text/plain;encoding=utf-8;base64,<contents|base64>
```

in the resulting Ignition config.

See https://coreos.github.io/ignition/configuration-v3_2/ for the Ignition spec.


## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Update tests
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
