### PR TITLE
Aggregate read-only permissions for MachineConfig resources to `cluster-reader`

### DIFF
--- a/class/openshift4-nodes.yml
+++ b/class/openshift4-nodes.yml
@@ -13,5 +13,6 @@ parameters:
           - openshift4-nodes/component/container-runtime.jsonnet
           - openshift4-nodes/component/oc-debug-node.jsonnet
           - openshift4-nodes/component/metrics.jsonnet
+          - openshift4-nodes/component/aggregated-clusterroles.jsonnet
         input_type: jsonnet
         output_path: openshift4-nodes/

--- a/component/aggregated-clusterroles.jsonnet
+++ b/component/aggregated-clusterroles.jsonnet
@@ -1,0 +1,24 @@
+local kube = import 'lib/kube.libjsonnet';
+
+{
+  '01_aggregated_clusterroles': [
+    kube.ClusterRole('syn-openshift4-nodes-cluster-reader') {
+      metadata+: {
+        annotations+: {
+          'rbac.authorization.k8s.io/aggregate-to-cluster-reader': 'true',
+        },
+      },
+      rules: [
+        {
+          apiGroups: [ 'machineconfiguration.openshift.io' ],
+          resources: [ 'machineconfigs' ],
+          verbs: [
+            'get',
+            'list',
+            'watch',
+          ],
+        },
+      ],
+    },
+  ],
+}

--- a/tests/golden/defaults/openshift4-nodes/openshift4-nodes/01_aggregated_clusterroles.yaml
+++ b/tests/golden/defaults/openshift4-nodes/openshift4-nodes/01_aggregated_clusterroles.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: 'true'
+  labels:
+    name: syn-openshift4-nodes-cluster-reader
+  name: syn-openshift4-nodes-cluster-reader
+rules:
+  - apiGroups:
+      - machineconfiguration.openshift.io
+    resources:
+      - machineconfigs
+    verbs:
+      - get
+      - list
+      - watch

--- a/tests/golden/gcp/openshift4-nodes/openshift4-nodes/01_aggregated_clusterroles.yaml
+++ b/tests/golden/gcp/openshift4-nodes/openshift4-nodes/01_aggregated_clusterroles.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: 'true'
+  labels:
+    name: syn-openshift4-nodes-cluster-reader
+  name: syn-openshift4-nodes-cluster-reader
+rules:
+  - apiGroups:
+      - machineconfiguration.openshift.io
+    resources:
+      - machineconfigs
+    verbs:
+      - get
+      - list
+      - watch

--- a/tests/golden/machineconfig/openshift4-nodes/openshift4-nodes/01_aggregated_clusterroles.yaml
+++ b/tests/golden/machineconfig/openshift4-nodes/openshift4-nodes/01_aggregated_clusterroles.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: 'true'
+  labels:
+    name: syn-openshift4-nodes-cluster-reader
+  name: syn-openshift4-nodes-cluster-reader
+rules:
+  - apiGroups:
+      - machineconfiguration.openshift.io
+    resources:
+      - machineconfigs
+    verbs:
+      - get
+      - list
+      - watch

--- a/tests/golden/maxpods/openshift4-nodes/openshift4-nodes/01_aggregated_clusterroles.yaml
+++ b/tests/golden/maxpods/openshift4-nodes/openshift4-nodes/01_aggregated_clusterroles.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: 'true'
+  labels:
+    name: syn-openshift4-nodes-cluster-reader
+  name: syn-openshift4-nodes-cluster-reader
+rules:
+  - apiGroups:
+      - machineconfiguration.openshift.io
+    resources:
+      - machineconfigs
+    verbs:
+      - get
+      - list
+      - watch

--- a/tests/golden/pidslimit/openshift4-nodes/openshift4-nodes/01_aggregated_clusterroles.yaml
+++ b/tests/golden/pidslimit/openshift4-nodes/openshift4-nodes/01_aggregated_clusterroles.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: 'true'
+  labels:
+    name: syn-openshift4-nodes-cluster-reader
+  name: syn-openshift4-nodes-cluster-reader
+rules:
+  - apiGroups:
+      - machineconfiguration.openshift.io
+    resources:
+      - machineconfigs
+    verbs:
+      - get
+      - list
+      - watch

--- a/tests/golden/syn-monitoring/openshift4-nodes/openshift4-nodes/01_aggregated_clusterroles.yaml
+++ b/tests/golden/syn-monitoring/openshift4-nodes/openshift4-nodes/01_aggregated_clusterroles.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: 'true'
+  labels:
+    name: syn-openshift4-nodes-cluster-reader
+  name: syn-openshift4-nodes-cluster-reader
+rules:
+  - apiGroups:
+      - machineconfiguration.openshift.io
+    resources:
+      - machineconfigs
+    verbs:
+      - get
+      - list
+      - watch


### PR DESCRIPTION
The other custom resources (MachineConfigPools, ControllerConfigs, KubeletConfigs, and ContainerRuntimeConfigs) are covered by cluster role `system:openshift:machine-config-operator:cluster-reader`.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
