### PR TITLE
Fix aggregating read permissions for machineconfig resources

### DIFF
--- a/component/aggregated-clusterroles.jsonnet
+++ b/component/aggregated-clusterroles.jsonnet
@@ -4,7 +4,7 @@ local kube = import 'lib/kube.libjsonnet';
   '01_aggregated_clusterroles': [
     kube.ClusterRole('syn-openshift4-nodes-cluster-reader') {
       metadata+: {
-        annotations+: {
+        labels+: {
           'rbac.authorization.k8s.io/aggregate-to-cluster-reader': 'true',
         },
       },

--- a/tests/golden/defaults/openshift4-nodes/openshift4-nodes/01_aggregated_clusterroles.yaml
+++ b/tests/golden/defaults/openshift4-nodes/openshift4-nodes/01_aggregated_clusterroles.yaml
@@ -1,10 +1,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    rbac.authorization.k8s.io/aggregate-to-cluster-reader: 'true'
+  annotations: {}
   labels:
     name: syn-openshift4-nodes-cluster-reader
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: 'true'
   name: syn-openshift4-nodes-cluster-reader
 rules:
   - apiGroups:

--- a/tests/golden/gcp/openshift4-nodes/openshift4-nodes/01_aggregated_clusterroles.yaml
+++ b/tests/golden/gcp/openshift4-nodes/openshift4-nodes/01_aggregated_clusterroles.yaml
@@ -1,10 +1,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    rbac.authorization.k8s.io/aggregate-to-cluster-reader: 'true'
+  annotations: {}
   labels:
     name: syn-openshift4-nodes-cluster-reader
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: 'true'
   name: syn-openshift4-nodes-cluster-reader
 rules:
   - apiGroups:

--- a/tests/golden/machineconfig/openshift4-nodes/openshift4-nodes/01_aggregated_clusterroles.yaml
+++ b/tests/golden/machineconfig/openshift4-nodes/openshift4-nodes/01_aggregated_clusterroles.yaml
@@ -1,10 +1,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    rbac.authorization.k8s.io/aggregate-to-cluster-reader: 'true'
+  annotations: {}
   labels:
     name: syn-openshift4-nodes-cluster-reader
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: 'true'
   name: syn-openshift4-nodes-cluster-reader
 rules:
   - apiGroups:

--- a/tests/golden/maxpods/openshift4-nodes/openshift4-nodes/01_aggregated_clusterroles.yaml
+++ b/tests/golden/maxpods/openshift4-nodes/openshift4-nodes/01_aggregated_clusterroles.yaml
@@ -1,10 +1,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    rbac.authorization.k8s.io/aggregate-to-cluster-reader: 'true'
+  annotations: {}
   labels:
     name: syn-openshift4-nodes-cluster-reader
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: 'true'
   name: syn-openshift4-nodes-cluster-reader
 rules:
   - apiGroups:

--- a/tests/golden/pidslimit/openshift4-nodes/openshift4-nodes/01_aggregated_clusterroles.yaml
+++ b/tests/golden/pidslimit/openshift4-nodes/openshift4-nodes/01_aggregated_clusterroles.yaml
@@ -1,10 +1,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    rbac.authorization.k8s.io/aggregate-to-cluster-reader: 'true'
+  annotations: {}
   labels:
     name: syn-openshift4-nodes-cluster-reader
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: 'true'
   name: syn-openshift4-nodes-cluster-reader
 rules:
   - apiGroups:

--- a/tests/golden/syn-monitoring/openshift4-nodes/openshift4-nodes/01_aggregated_clusterroles.yaml
+++ b/tests/golden/syn-monitoring/openshift4-nodes/openshift4-nodes/01_aggregated_clusterroles.yaml
@@ -1,10 +1,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    rbac.authorization.k8s.io/aggregate-to-cluster-reader: 'true'
+  annotations: {}
   labels:
     name: syn-openshift4-nodes-cluster-reader
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: 'true'
   name: syn-openshift4-nodes-cluster-reader
 rules:
   - apiGroups:


### PR DESCRIPTION
Correctly use `rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"` as a label instead of an annotation.

Fixes #59 


## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
