### PR TITLE
Fix machineconfig inline file source encoding specification

### DIFF
--- a/component/machine-configs.jsonnet
+++ b/component/machine-configs.jsonnet
@@ -57,7 +57,7 @@ local machineConfigs = [
                   contents+: {
                     inline:: null,
                     source:
-                      'data:text/plain;encoding=utf-8;base64,%s' %
+                      'data:text/plain;charset=utf-8;base64,%s' %
                       std.base64(f.contents.inline),
                   },
                 }

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -312,7 +312,7 @@ machineConfigs:
               overwrite: true
               contents:
                 # The contents of `inline` get rendered as
-                # `source: 'data:text/plain;encoding=utf-8;base64,<inline|base64>'`
+                # `source: 'data:text/plain;charset=utf-8;base64,<inline|base64>'`
                 inline: |
                   # Use ch.pool.ntp.org
                   pool ch.pool.ntp.org iburst
@@ -366,13 +366,13 @@ spec:
     storage:
       files:
         - contents:
-            source: data:text/plain;encoding=utf-8;base64,IyBVc2UgY2gucG9vbC5udHAub3JnCnBvb2wgY2gucG9vbC5udHAub3JnIGlidXJzdAojIFJlc3QgaXMgY29waWVkIGZyb20gdGhlIGRlZmF1bHQgY29uZmlnCmRyaWZ0ZmlsZSAvdmFyL2xpYi9jaHJvbnkvZHJpZnQKbWFrZXN0ZXAgMS4wIDMKcnRjc3luYwprZXlmaWxlIC9ldGMvY2hyb255LmtleXMKbGVhcHNlY3R6IHJpZ2h0L1VUQwpsb2dkaXIgL3Zhci9sb2cvY2hyb255Cg== <2>
+            source: data:text/plain;charset=utf-8;base64,IyBVc2UgY2gucG9vbC5udHAub3JnCnBvb2wgY2gucG9vbC5udHAub3JnIGlidXJzdAojIFJlc3QgaXMgY29waWVkIGZyb20gdGhlIGRlZmF1bHQgY29uZmlnCmRyaWZ0ZmlsZSAvdmFyL2xpYi9jaHJvbnkvZHJpZnQKbWFrZXN0ZXAgMS4wIDMKcnRjc3luYwprZXlmaWxlIC9ldGMvY2hyb255LmtleXMKbGVhcHNlY3R6IHJpZ2h0L1VUQwpsb2dkaXIgL3Zhci9sb2cvY2hyb255Cg== <2>
           mode: 420
           overwrite: true
           path: /etc/chrony.conf
 ----
 <1> The original inline file contents are added as an annotation to the resulting machine config object.
-<2> The actual entry in the files list in the Ignition config is encoded with base64 and added as a data scheme value (`data:text/plain;encoding=utf-8;base64,...`) in the `contents.source` field.
+<2> The actual entry in the files list in the Ignition config is encoded with base64 and added as a data scheme value (`data:text/plain;charset=utf-8;base64,...`) in the `contents.source` field.
 See the https://coreos.github.io/ignition/configuration-v3_2/[Ignition spec] for more details on supported ways to specify file contents.
 
 [NOTE]

--- a/tests/golden/machineconfig/openshift4-nodes/openshift4-nodes/10_machineconfigs.yaml
+++ b/tests/golden/machineconfig/openshift4-nodes/openshift4-nodes/10_machineconfigs.yaml
@@ -68,7 +68,7 @@ spec:
     storage:
       files:
         - contents:
-            source: data:text/plain;encoding=utf-8;base64,IyBVc2UgY2gucG9vbC5udHAub3JnCnBvb2wgY2gucG9vbC5udHAub3JnIGlidXJzdAojIFJlc3QgaXMgY29waWVkIGZyb20gdGhlIGRlZmF1bHQgY29uZmlnCmRyaWZ0ZmlsZSAvdmFyL2xpYi9jaHJvbnkvZHJpZnQKbWFrZXN0ZXAgMS4wIDMKcnRjc3luYwprZXlmaWxlIC9ldGMvY2hyb255LmtleXMKbGVhcHNlY3R6IHJpZ2h0L1VUQwpsb2dkaXIgL3Zhci9sb2cvY2hyb255Cg==
+            source: data:text/plain;charset=utf-8;base64,IyBVc2UgY2gucG9vbC5udHAub3JnCnBvb2wgY2gucG9vbC5udHAub3JnIGlidXJzdAojIFJlc3QgaXMgY29waWVkIGZyb20gdGhlIGRlZmF1bHQgY29uZmlnCmRyaWZ0ZmlsZSAvdmFyL2xpYi9jaHJvbnkvZHJpZnQKbWFrZXN0ZXAgMS4wIDMKcnRjc3luYwprZXlmaWxlIC9ldGMvY2hyb255LmtleXMKbGVhcHNlY3R6IHJpZ2h0L1VUQwpsb2dkaXIgL3Zhci9sb2cvY2hyb255Cg==
           mode: 420
           overwrite: true
           path: /etc/chrony.conf


### PR DESCRIPTION
The `data` URL scheme uses `charset` and not `encoding` to specify the encoding of the inline data.

This commit fixes the component to use `charset=utf-8` instead of `encoding=utf-8` when generating `data` URLs.

See also https://datatracker.ietf.org/doc/html/rfc2397




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
