### PR TITLE
Ignore `spec.replicas` for autoscaled MachineSets in ArgoCD sync

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/projectsyn/commodore-component-template.git",
-  "commit": "f12cbb49f928cf689cf39b98d8d7c9e88fb289f6",
+  "commit": "98d16f99766e6c6d97322dbe42e058f0e2bf73d0",
   "checkout": "main",
   "context": {
     "cookiecutter": {

--- a/component/app.jsonnet
+++ b/component/app.jsonnet
@@ -6,7 +6,7 @@ local argocd = import 'lib/argocd.libjsonnet';
 local app = argocd.App('openshift4-nodes', params.machineApiNamespace);
 
 local appPath =
-  local project = std.get(app, 'spec', { project: 'syn' }).project;
+  local project = std.get(std.get(app, 'spec', {}), 'project', 'syn');
   if project == 'syn' then 'apps' else 'apps-%s' % project;
 
 {

--- a/component/app.jsonnet
+++ b/component/app.jsonnet
@@ -3,7 +3,18 @@ local inv = kap.inventory();
 local params = inv.parameters.openshift4_nodes;
 local argocd = import 'lib/argocd.libjsonnet';
 
-local app = argocd.App('openshift4-nodes', params.machineApiNamespace);
+local autoscaler = import 'autoscaler.jsonnet';
+
+local app = argocd.App('openshift4-nodes', params.machineApiNamespace) {
+  spec+: {
+    ignoreDifferences+: autoscaler.ignoreDifferences,
+    syncPolicy+: {
+      syncOptions+: [
+        'RespectIgnoreDifferences=true',
+      ],
+    },
+  },
+};
 
 local appPath =
   local project = std.get(std.get(app, 'spec', {}), 'project', 'syn');

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -318,6 +318,8 @@ Each key value pair in this parameter is used to create a `MachineAutoscaler` re
 The component expects that each key matches a `MachineSet` which is configured through one of the parameters `nodeGroups` or `machineSets`.
 The component will raise an error if it finds a key which doesn't have a matching entry in `nodeGroups` or `machineSets`.
 
+NOTE: The component will configure ArgoCD to ignore changes to `spec.replicas` for each `MachineSet` resources targeted by a `MachineAutoscaler`.
+
 The value associated with each key is used as the base configuration for `.spec` of the resulting `MachineAutoscaler` resource.
 The component will always configure `.spec.scaleTargetRef.name` with the key to ensure the `MachineAutoscaler` resource targets the desired `MachineSet`.
 

--- a/tests/golden/autoscaling/openshift4-nodes/apps/openshift4-nodes.yaml
+++ b/tests/golden/autoscaling/openshift4-nodes/apps/openshift4-nodes.yaml
@@ -1,0 +1,10 @@
+spec:
+  ignoreDifferences:
+    - group: machine.openshift.io
+      jsonPointers:
+        - /spec/replicas
+      kind: MachineSet
+      name: app
+  syncPolicy:
+    syncOptions:
+      - RespectIgnoreDifferences=true

--- a/tests/golden/defaults/openshift4-nodes/apps/openshift4-nodes.yaml
+++ b/tests/golden/defaults/openshift4-nodes/apps/openshift4-nodes.yaml
@@ -1,0 +1,5 @@
+spec:
+  ignoreDifferences: []
+  syncPolicy:
+    syncOptions:
+      - RespectIgnoreDifferences=true

--- a/tests/golden/gcp/openshift4-nodes/apps/openshift4-nodes.yaml
+++ b/tests/golden/gcp/openshift4-nodes/apps/openshift4-nodes.yaml
@@ -1,0 +1,5 @@
+spec:
+  ignoreDifferences: []
+  syncPolicy:
+    syncOptions:
+      - RespectIgnoreDifferences=true

--- a/tests/golden/machineconfig/openshift4-nodes/apps/openshift4-nodes.yaml
+++ b/tests/golden/machineconfig/openshift4-nodes/apps/openshift4-nodes.yaml
@@ -1,0 +1,5 @@
+spec:
+  ignoreDifferences: []
+  syncPolicy:
+    syncOptions:
+      - RespectIgnoreDifferences=true

--- a/tests/golden/maxpods/openshift4-nodes/apps/openshift4-nodes.yaml
+++ b/tests/golden/maxpods/openshift4-nodes/apps/openshift4-nodes.yaml
@@ -1,0 +1,5 @@
+spec:
+  ignoreDifferences: []
+  syncPolicy:
+    syncOptions:
+      - RespectIgnoreDifferences=true

--- a/tests/golden/pidslimit/openshift4-nodes/apps/openshift4-nodes.yaml
+++ b/tests/golden/pidslimit/openshift4-nodes/apps/openshift4-nodes.yaml
@@ -1,0 +1,5 @@
+spec:
+  ignoreDifferences: []
+  syncPolicy:
+    syncOptions:
+      - RespectIgnoreDifferences=true

--- a/tests/golden/remove-machineconfigpool/openshift4-nodes/apps/openshift4-nodes.yaml
+++ b/tests/golden/remove-machineconfigpool/openshift4-nodes/apps/openshift4-nodes.yaml
@@ -1,0 +1,5 @@
+spec:
+  ignoreDifferences: []
+  syncPolicy:
+    syncOptions:
+      - RespectIgnoreDifferences=true


### PR DESCRIPTION
We need to ignore changes to `spec.replica` when diffing *and* syncing MachineSets which are managed by a `MachineAutoscaler`.

To do so we 1) dynamically configure `spec.ignoreDifferences` in the ArgoCD app to ignore `spec.replicas` of each `MachineSet` that's targeted by a `MachineAutoscaler` and 2) set ArgoCD sync option `RespectIgnoreDifferences=true` to ensure that we don't overwrite the machine autoscaler's value in `spec.replicas` if we're applying other changes.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
