### PR TITLE
Cronjob to prune unused rendered MachineConfigs

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -119,3 +119,9 @@ parameters:
       shadowRangeConfigMap:
         namespace: cilium
         name: eip-shadow-ranges
+
+    images:
+      oc:
+        registry: quay.io
+        repository: appuio/oc
+        tag: v4.16

--- a/class/openshift4-nodes.yml
+++ b/class/openshift4-nodes.yml
@@ -16,5 +16,6 @@ parameters:
           - openshift4-nodes/component/aggregated-clusterroles.jsonnet
           - openshift4-nodes/component/egress-interfaces.jsonnet
           - openshift4-nodes/component/autoscaler.jsonnet
+          - openshift4-nodes/component/prune-machine-configs.jsonnet
         input_type: jsonnet
         output_path: openshift4-nodes/

--- a/component/prune-machine-configs.jsonnet
+++ b/component/prune-machine-configs.jsonnet
@@ -1,0 +1,102 @@
+local common = import 'common.libsonnet';
+local com = import 'lib/commodore.libjsonnet';
+local kap = import 'lib/kapitan.libjsonnet';
+local kube = import 'lib/kube.libjsonnet';
+local inv = kap.inventory();
+
+local params = inv.parameters.openshift4_nodes;
+
+local namespace = {
+  metadata+: {
+    namespace: 'openshift-machine-config-operator',
+  },
+};
+
+local pruningRBAC =
+  local sa = kube.ServiceAccount('appuio-machineconfig-pruner') + namespace;
+  local cluster_role = kube.ClusterRole('appuio:machineconfig-pruner') {
+    rules: [
+      {
+        apiGroups: [ 'machineconfiguration.openshift.io' ],
+        resources: [ 'machineconfigs' ],
+        verbs: [ 'get', 'list', 'delete' ],
+      },
+      {
+        apiGroups: [ 'machineconfiguration.openshift.io' ],
+        resources: [ 'machineconfigpools' ],
+        verbs: [ 'get', 'list' ],
+      },
+      {
+        apiGroups: [ '' ],
+        resources: [ 'nodes' ],
+        verbs: [ 'get', 'list' ],
+      },
+    ],
+  };
+  local cluster_role_binding =
+    kube.ClusterRoleBinding('appuio:machineconfig-pruner') {
+      subjects_: [ sa ],
+      roleRef_: cluster_role,
+    };
+  {
+    sa: sa,
+    cluster_role: cluster_role,
+    cluster_role_binding: cluster_role_binding,
+  };
+
+
+local pruneScript = kube.ConfigMap('appuio-prune-machineconfigs') + namespace {
+  data: {
+    'machineconfig_pruning.sh': (importstr 'scripts/machineconfig_pruning.sh'),
+  },
+};
+
+local pruneCronJob = kube.CronJob('appuio-prune-machineconfigs') + namespace {
+  spec+: {
+    failedJobsHistoryLimit: 3,
+    // Wednesdays at 11:00
+    schedule: '0 11 * * 3',
+    timeZone: 'Europe/Zurich',
+    jobTemplate+: {
+      spec+: {
+        template+: {
+          spec+: {
+            containers_+: {
+              pruner: kube.Container('prune-machineconfigs') {
+                image: '%(registry)s/%(repository)s:%(tag)s' % params.images.oc,
+                workingDir: '/export',
+                command: [ '/scripts/machineconfig_pruning.sh' ],
+                env_+: {
+                  HOME: '/export',
+                },
+                volumeMounts_+: {
+                  export: {
+                    mountPath: '/export',
+                  },
+                  scripts: {
+                    mountPath: '/scripts',
+                  },
+                },
+              },
+            },
+            volumes_+: {
+              export: {
+                emptyDir: {},
+              },
+              scripts: {
+                configMap: {
+                  name: 'appuio-prune-machineconfigs',
+                  defaultMode: std.parseOctal('0550'),
+                },
+              },
+            },
+            serviceAccountName: pruningRBAC.sa.metadata.name,
+          },
+        },
+      },
+    },
+  },
+};
+{
+  machineconfig_pruning: [ pruneScript, pruneCronJob ] + std.objectValues(pruningRBAC),
+}

--- a/component/scripts/machineconfig_pruning.sh
+++ b/component/scripts/machineconfig_pruning.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -exo pipefail
+
+for pool in $(kubectl get machineconfigpool -ojson | jq -r '.items[].metadata.name'); do
+  oc adm prune renderedmachineconfigs list --pool-name="$pool" |\
+    grep 'in use: false' |\
+    # keep 5 newest mc
+    head -n-5 |\
+    cut -d' ' -f1 |\
+    while read -r mc; do
+      kubectl delete machineconfig "$mc"
+    done
+done

--- a/tests/golden/autoscaling/openshift4-nodes/openshift4-nodes/machineconfig_pruning.yaml
+++ b/tests/golden/autoscaling/openshift4-nodes/openshift4-nodes/machineconfig_pruning.yaml
@@ -1,0 +1,134 @@
+apiVersion: v1
+data:
+  machineconfig_pruning.sh: |
+    #!/bin/bash
+    set -exo pipefail
+
+    for pool in $(kubectl get machineconfigpool -ojson | jq -r '.items[].metadata.name'); do
+      oc adm prune renderedmachineconfigs list --pool-name="$pool" |\
+        grep 'in use: false' |\
+        # keep 5 newest mc
+        head -n-5 |\
+        cut -d' ' -f1 |\
+        while read -r mc; do
+          kubectl delete machineconfig "$mc"
+        done
+    done
+kind: ConfigMap
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-prune-machineconfigs
+  name: appuio-prune-machineconfigs
+  namespace: openshift-machine-config-operator
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-prune-machineconfigs
+  name: appuio-prune-machineconfigs
+  namespace: openshift-machine-config-operator
+spec:
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      completions: 1
+      parallelism: 1
+      template:
+        metadata:
+          labels:
+            name: appuio-prune-machineconfigs
+        spec:
+          containers:
+            - args: []
+              command:
+                - /scripts/machineconfig_pruning.sh
+              env:
+                - name: HOME
+                  value: /export
+              image: quay.io/appuio/oc:v4.16
+              imagePullPolicy: IfNotPresent
+              name: prune-machineconfigs
+              ports: []
+              stdin: false
+              tty: false
+              volumeMounts:
+                - mountPath: /export
+                  name: export
+                - mountPath: /scripts
+                  name: scripts
+              workingDir: /export
+          imagePullSecrets: []
+          initContainers: []
+          restartPolicy: OnFailure
+          serviceAccountName: appuio-machineconfig-pruner
+          terminationGracePeriodSeconds: 30
+          volumes:
+            - emptyDir: {}
+              name: export
+            - configMap:
+                defaultMode: 360
+                name: appuio-prune-machineconfigs
+              name: scripts
+  schedule: 0 11 * * 3
+  successfulJobsHistoryLimit: 10
+  timeZone: Europe/Zurich
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-machineconfig-pruner
+  name: appuio:machineconfig-pruner
+rules:
+  - apiGroups:
+      - machineconfiguration.openshift.io
+    resources:
+      - machineconfigs
+    verbs:
+      - get
+      - list
+      - delete
+  - apiGroups:
+      - machineconfiguration.openshift.io
+    resources:
+      - machineconfigpools
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - ''
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-machineconfig-pruner
+  name: appuio:machineconfig-pruner
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: appuio:machineconfig-pruner
+subjects:
+  - kind: ServiceAccount
+    name: appuio-machineconfig-pruner
+    namespace: openshift-machine-config-operator
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-machineconfig-pruner
+  name: appuio-machineconfig-pruner
+  namespace: openshift-machine-config-operator

--- a/tests/golden/defaults/openshift4-nodes/openshift4-nodes/machineconfig_pruning.yaml
+++ b/tests/golden/defaults/openshift4-nodes/openshift4-nodes/machineconfig_pruning.yaml
@@ -1,0 +1,134 @@
+apiVersion: v1
+data:
+  machineconfig_pruning.sh: |
+    #!/bin/bash
+    set -exo pipefail
+
+    for pool in $(kubectl get machineconfigpool -ojson | jq -r '.items[].metadata.name'); do
+      oc adm prune renderedmachineconfigs list --pool-name="$pool" |\
+        grep 'in use: false' |\
+        # keep 5 newest mc
+        head -n-5 |\
+        cut -d' ' -f1 |\
+        while read -r mc; do
+          kubectl delete machineconfig "$mc"
+        done
+    done
+kind: ConfigMap
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-prune-machineconfigs
+  name: appuio-prune-machineconfigs
+  namespace: openshift-machine-config-operator
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-prune-machineconfigs
+  name: appuio-prune-machineconfigs
+  namespace: openshift-machine-config-operator
+spec:
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      completions: 1
+      parallelism: 1
+      template:
+        metadata:
+          labels:
+            name: appuio-prune-machineconfigs
+        spec:
+          containers:
+            - args: []
+              command:
+                - /scripts/machineconfig_pruning.sh
+              env:
+                - name: HOME
+                  value: /export
+              image: quay.io/appuio/oc:v4.16
+              imagePullPolicy: IfNotPresent
+              name: prune-machineconfigs
+              ports: []
+              stdin: false
+              tty: false
+              volumeMounts:
+                - mountPath: /export
+                  name: export
+                - mountPath: /scripts
+                  name: scripts
+              workingDir: /export
+          imagePullSecrets: []
+          initContainers: []
+          restartPolicy: OnFailure
+          serviceAccountName: appuio-machineconfig-pruner
+          terminationGracePeriodSeconds: 30
+          volumes:
+            - emptyDir: {}
+              name: export
+            - configMap:
+                defaultMode: 360
+                name: appuio-prune-machineconfigs
+              name: scripts
+  schedule: 0 11 * * 3
+  successfulJobsHistoryLimit: 10
+  timeZone: Europe/Zurich
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-machineconfig-pruner
+  name: appuio:machineconfig-pruner
+rules:
+  - apiGroups:
+      - machineconfiguration.openshift.io
+    resources:
+      - machineconfigs
+    verbs:
+      - get
+      - list
+      - delete
+  - apiGroups:
+      - machineconfiguration.openshift.io
+    resources:
+      - machineconfigpools
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - ''
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-machineconfig-pruner
+  name: appuio:machineconfig-pruner
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: appuio:machineconfig-pruner
+subjects:
+  - kind: ServiceAccount
+    name: appuio-machineconfig-pruner
+    namespace: openshift-machine-config-operator
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-machineconfig-pruner
+  name: appuio-machineconfig-pruner
+  namespace: openshift-machine-config-operator

--- a/tests/golden/gcp/openshift4-nodes/openshift4-nodes/machineconfig_pruning.yaml
+++ b/tests/golden/gcp/openshift4-nodes/openshift4-nodes/machineconfig_pruning.yaml
@@ -1,0 +1,134 @@
+apiVersion: v1
+data:
+  machineconfig_pruning.sh: |
+    #!/bin/bash
+    set -exo pipefail
+
+    for pool in $(kubectl get machineconfigpool -ojson | jq -r '.items[].metadata.name'); do
+      oc adm prune renderedmachineconfigs list --pool-name="$pool" |\
+        grep 'in use: false' |\
+        # keep 5 newest mc
+        head -n-5 |\
+        cut -d' ' -f1 |\
+        while read -r mc; do
+          kubectl delete machineconfig "$mc"
+        done
+    done
+kind: ConfigMap
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-prune-machineconfigs
+  name: appuio-prune-machineconfigs
+  namespace: openshift-machine-config-operator
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-prune-machineconfigs
+  name: appuio-prune-machineconfigs
+  namespace: openshift-machine-config-operator
+spec:
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      completions: 1
+      parallelism: 1
+      template:
+        metadata:
+          labels:
+            name: appuio-prune-machineconfigs
+        spec:
+          containers:
+            - args: []
+              command:
+                - /scripts/machineconfig_pruning.sh
+              env:
+                - name: HOME
+                  value: /export
+              image: quay.io/appuio/oc:v4.16
+              imagePullPolicy: IfNotPresent
+              name: prune-machineconfigs
+              ports: []
+              stdin: false
+              tty: false
+              volumeMounts:
+                - mountPath: /export
+                  name: export
+                - mountPath: /scripts
+                  name: scripts
+              workingDir: /export
+          imagePullSecrets: []
+          initContainers: []
+          restartPolicy: OnFailure
+          serviceAccountName: appuio-machineconfig-pruner
+          terminationGracePeriodSeconds: 30
+          volumes:
+            - emptyDir: {}
+              name: export
+            - configMap:
+                defaultMode: 360
+                name: appuio-prune-machineconfigs
+              name: scripts
+  schedule: 0 11 * * 3
+  successfulJobsHistoryLimit: 10
+  timeZone: Europe/Zurich
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-machineconfig-pruner
+  name: appuio:machineconfig-pruner
+rules:
+  - apiGroups:
+      - machineconfiguration.openshift.io
+    resources:
+      - machineconfigs
+    verbs:
+      - get
+      - list
+      - delete
+  - apiGroups:
+      - machineconfiguration.openshift.io
+    resources:
+      - machineconfigpools
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - ''
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-machineconfig-pruner
+  name: appuio:machineconfig-pruner
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: appuio:machineconfig-pruner
+subjects:
+  - kind: ServiceAccount
+    name: appuio-machineconfig-pruner
+    namespace: openshift-machine-config-operator
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-machineconfig-pruner
+  name: appuio-machineconfig-pruner
+  namespace: openshift-machine-config-operator

--- a/tests/golden/machineconfig/openshift4-nodes/openshift4-nodes/machineconfig_pruning.yaml
+++ b/tests/golden/machineconfig/openshift4-nodes/openshift4-nodes/machineconfig_pruning.yaml
@@ -1,0 +1,134 @@
+apiVersion: v1
+data:
+  machineconfig_pruning.sh: |
+    #!/bin/bash
+    set -exo pipefail
+
+    for pool in $(kubectl get machineconfigpool -ojson | jq -r '.items[].metadata.name'); do
+      oc adm prune renderedmachineconfigs list --pool-name="$pool" |\
+        grep 'in use: false' |\
+        # keep 5 newest mc
+        head -n-5 |\
+        cut -d' ' -f1 |\
+        while read -r mc; do
+          kubectl delete machineconfig "$mc"
+        done
+    done
+kind: ConfigMap
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-prune-machineconfigs
+  name: appuio-prune-machineconfigs
+  namespace: openshift-machine-config-operator
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-prune-machineconfigs
+  name: appuio-prune-machineconfigs
+  namespace: openshift-machine-config-operator
+spec:
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      completions: 1
+      parallelism: 1
+      template:
+        metadata:
+          labels:
+            name: appuio-prune-machineconfigs
+        spec:
+          containers:
+            - args: []
+              command:
+                - /scripts/machineconfig_pruning.sh
+              env:
+                - name: HOME
+                  value: /export
+              image: quay.io/appuio/oc:v4.16
+              imagePullPolicy: IfNotPresent
+              name: prune-machineconfigs
+              ports: []
+              stdin: false
+              tty: false
+              volumeMounts:
+                - mountPath: /export
+                  name: export
+                - mountPath: /scripts
+                  name: scripts
+              workingDir: /export
+          imagePullSecrets: []
+          initContainers: []
+          restartPolicy: OnFailure
+          serviceAccountName: appuio-machineconfig-pruner
+          terminationGracePeriodSeconds: 30
+          volumes:
+            - emptyDir: {}
+              name: export
+            - configMap:
+                defaultMode: 360
+                name: appuio-prune-machineconfigs
+              name: scripts
+  schedule: 0 11 * * 3
+  successfulJobsHistoryLimit: 10
+  timeZone: Europe/Zurich
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-machineconfig-pruner
+  name: appuio:machineconfig-pruner
+rules:
+  - apiGroups:
+      - machineconfiguration.openshift.io
+    resources:
+      - machineconfigs
+    verbs:
+      - get
+      - list
+      - delete
+  - apiGroups:
+      - machineconfiguration.openshift.io
+    resources:
+      - machineconfigpools
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - ''
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-machineconfig-pruner
+  name: appuio:machineconfig-pruner
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: appuio:machineconfig-pruner
+subjects:
+  - kind: ServiceAccount
+    name: appuio-machineconfig-pruner
+    namespace: openshift-machine-config-operator
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-machineconfig-pruner
+  name: appuio-machineconfig-pruner
+  namespace: openshift-machine-config-operator

--- a/tests/golden/maxpods/openshift4-nodes/openshift4-nodes/machineconfig_pruning.yaml
+++ b/tests/golden/maxpods/openshift4-nodes/openshift4-nodes/machineconfig_pruning.yaml
@@ -1,0 +1,134 @@
+apiVersion: v1
+data:
+  machineconfig_pruning.sh: |
+    #!/bin/bash
+    set -exo pipefail
+
+    for pool in $(kubectl get machineconfigpool -ojson | jq -r '.items[].metadata.name'); do
+      oc adm prune renderedmachineconfigs list --pool-name="$pool" |\
+        grep 'in use: false' |\
+        # keep 5 newest mc
+        head -n-5 |\
+        cut -d' ' -f1 |\
+        while read -r mc; do
+          kubectl delete machineconfig "$mc"
+        done
+    done
+kind: ConfigMap
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-prune-machineconfigs
+  name: appuio-prune-machineconfigs
+  namespace: openshift-machine-config-operator
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-prune-machineconfigs
+  name: appuio-prune-machineconfigs
+  namespace: openshift-machine-config-operator
+spec:
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      completions: 1
+      parallelism: 1
+      template:
+        metadata:
+          labels:
+            name: appuio-prune-machineconfigs
+        spec:
+          containers:
+            - args: []
+              command:
+                - /scripts/machineconfig_pruning.sh
+              env:
+                - name: HOME
+                  value: /export
+              image: quay.io/appuio/oc:v4.16
+              imagePullPolicy: IfNotPresent
+              name: prune-machineconfigs
+              ports: []
+              stdin: false
+              tty: false
+              volumeMounts:
+                - mountPath: /export
+                  name: export
+                - mountPath: /scripts
+                  name: scripts
+              workingDir: /export
+          imagePullSecrets: []
+          initContainers: []
+          restartPolicy: OnFailure
+          serviceAccountName: appuio-machineconfig-pruner
+          terminationGracePeriodSeconds: 30
+          volumes:
+            - emptyDir: {}
+              name: export
+            - configMap:
+                defaultMode: 360
+                name: appuio-prune-machineconfigs
+              name: scripts
+  schedule: 0 11 * * 3
+  successfulJobsHistoryLimit: 10
+  timeZone: Europe/Zurich
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-machineconfig-pruner
+  name: appuio:machineconfig-pruner
+rules:
+  - apiGroups:
+      - machineconfiguration.openshift.io
+    resources:
+      - machineconfigs
+    verbs:
+      - get
+      - list
+      - delete
+  - apiGroups:
+      - machineconfiguration.openshift.io
+    resources:
+      - machineconfigpools
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - ''
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-machineconfig-pruner
+  name: appuio:machineconfig-pruner
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: appuio:machineconfig-pruner
+subjects:
+  - kind: ServiceAccount
+    name: appuio-machineconfig-pruner
+    namespace: openshift-machine-config-operator
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-machineconfig-pruner
+  name: appuio-machineconfig-pruner
+  namespace: openshift-machine-config-operator

--- a/tests/golden/pidslimit/openshift4-nodes/openshift4-nodes/machineconfig_pruning.yaml
+++ b/tests/golden/pidslimit/openshift4-nodes/openshift4-nodes/machineconfig_pruning.yaml
@@ -1,0 +1,134 @@
+apiVersion: v1
+data:
+  machineconfig_pruning.sh: |
+    #!/bin/bash
+    set -exo pipefail
+
+    for pool in $(kubectl get machineconfigpool -ojson | jq -r '.items[].metadata.name'); do
+      oc adm prune renderedmachineconfigs list --pool-name="$pool" |\
+        grep 'in use: false' |\
+        # keep 5 newest mc
+        head -n-5 |\
+        cut -d' ' -f1 |\
+        while read -r mc; do
+          kubectl delete machineconfig "$mc"
+        done
+    done
+kind: ConfigMap
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-prune-machineconfigs
+  name: appuio-prune-machineconfigs
+  namespace: openshift-machine-config-operator
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-prune-machineconfigs
+  name: appuio-prune-machineconfigs
+  namespace: openshift-machine-config-operator
+spec:
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      completions: 1
+      parallelism: 1
+      template:
+        metadata:
+          labels:
+            name: appuio-prune-machineconfigs
+        spec:
+          containers:
+            - args: []
+              command:
+                - /scripts/machineconfig_pruning.sh
+              env:
+                - name: HOME
+                  value: /export
+              image: quay.io/appuio/oc:v4.16
+              imagePullPolicy: IfNotPresent
+              name: prune-machineconfigs
+              ports: []
+              stdin: false
+              tty: false
+              volumeMounts:
+                - mountPath: /export
+                  name: export
+                - mountPath: /scripts
+                  name: scripts
+              workingDir: /export
+          imagePullSecrets: []
+          initContainers: []
+          restartPolicy: OnFailure
+          serviceAccountName: appuio-machineconfig-pruner
+          terminationGracePeriodSeconds: 30
+          volumes:
+            - emptyDir: {}
+              name: export
+            - configMap:
+                defaultMode: 360
+                name: appuio-prune-machineconfigs
+              name: scripts
+  schedule: 0 11 * * 3
+  successfulJobsHistoryLimit: 10
+  timeZone: Europe/Zurich
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-machineconfig-pruner
+  name: appuio:machineconfig-pruner
+rules:
+  - apiGroups:
+      - machineconfiguration.openshift.io
+    resources:
+      - machineconfigs
+    verbs:
+      - get
+      - list
+      - delete
+  - apiGroups:
+      - machineconfiguration.openshift.io
+    resources:
+      - machineconfigpools
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - ''
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-machineconfig-pruner
+  name: appuio:machineconfig-pruner
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: appuio:machineconfig-pruner
+subjects:
+  - kind: ServiceAccount
+    name: appuio-machineconfig-pruner
+    namespace: openshift-machine-config-operator
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-machineconfig-pruner
+  name: appuio-machineconfig-pruner
+  namespace: openshift-machine-config-operator

--- a/tests/golden/remove-machineconfigpool/openshift4-nodes/openshift4-nodes/machineconfig_pruning.yaml
+++ b/tests/golden/remove-machineconfigpool/openshift4-nodes/openshift4-nodes/machineconfig_pruning.yaml
@@ -1,0 +1,134 @@
+apiVersion: v1
+data:
+  machineconfig_pruning.sh: |
+    #!/bin/bash
+    set -exo pipefail
+
+    for pool in $(kubectl get machineconfigpool -ojson | jq -r '.items[].metadata.name'); do
+      oc adm prune renderedmachineconfigs list --pool-name="$pool" |\
+        grep 'in use: false' |\
+        # keep 5 newest mc
+        head -n-5 |\
+        cut -d' ' -f1 |\
+        while read -r mc; do
+          kubectl delete machineconfig "$mc"
+        done
+    done
+kind: ConfigMap
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-prune-machineconfigs
+  name: appuio-prune-machineconfigs
+  namespace: openshift-machine-config-operator
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-prune-machineconfigs
+  name: appuio-prune-machineconfigs
+  namespace: openshift-machine-config-operator
+spec:
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      completions: 1
+      parallelism: 1
+      template:
+        metadata:
+          labels:
+            name: appuio-prune-machineconfigs
+        spec:
+          containers:
+            - args: []
+              command:
+                - /scripts/machineconfig_pruning.sh
+              env:
+                - name: HOME
+                  value: /export
+              image: quay.io/appuio/oc:v4.16
+              imagePullPolicy: IfNotPresent
+              name: prune-machineconfigs
+              ports: []
+              stdin: false
+              tty: false
+              volumeMounts:
+                - mountPath: /export
+                  name: export
+                - mountPath: /scripts
+                  name: scripts
+              workingDir: /export
+          imagePullSecrets: []
+          initContainers: []
+          restartPolicy: OnFailure
+          serviceAccountName: appuio-machineconfig-pruner
+          terminationGracePeriodSeconds: 30
+          volumes:
+            - emptyDir: {}
+              name: export
+            - configMap:
+                defaultMode: 360
+                name: appuio-prune-machineconfigs
+              name: scripts
+  schedule: 0 11 * * 3
+  successfulJobsHistoryLimit: 10
+  timeZone: Europe/Zurich
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-machineconfig-pruner
+  name: appuio:machineconfig-pruner
+rules:
+  - apiGroups:
+      - machineconfiguration.openshift.io
+    resources:
+      - machineconfigs
+    verbs:
+      - get
+      - list
+      - delete
+  - apiGroups:
+      - machineconfiguration.openshift.io
+    resources:
+      - machineconfigpools
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - ''
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-machineconfig-pruner
+  name: appuio:machineconfig-pruner
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: appuio:machineconfig-pruner
+subjects:
+  - kind: ServiceAccount
+    name: appuio-machineconfig-pruner
+    namespace: openshift-machine-config-operator
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-machineconfig-pruner
+  name: appuio-machineconfig-pruner
+  namespace: openshift-machine-config-operator


### PR DESCRIPTION
Adds a cronjob to regularly (once a week) prune unused rendered machineconfigs. Uses `oc adm prune renderedmachinconfigs` as described in https://docs.openshift.com/container-platform/4.16/machine_configuration/machine-configs-garbage-collection.html#machine-configs-garbage-collection

Instead of pruning all unused rendered machineconfigs we keep the 5 most recent rendered machineconfigs for each machineconfigpool. This is useful for debugging issues and tasks like https://kb.vshn.ch/oc4/how-tos/force-reboot.html

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
