### PR TITLE
Add capacity alerts with autoscaling support

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -7,7 +7,7 @@
       "name": "OpenShift 4 Nodes",
       "slug": "openshift4-nodes",
       "parameter_key": "openshift4_nodes",
-      "test_cases": "defaults gcp maxpods pidslimit machineconfig remove-machineconfigpool autoscaling",
+      "test_cases": "defaults gcp maxpods pidslimit machineconfig remove-machineconfigpool autoscaling capacity",
       "add_lib": "n",
       "add_pp": "n",
       "add_golden": "y",
@@ -24,7 +24,8 @@
       "github_owner": "appuio",
       "github_name": "component-openshift4-nodes",
       "github_url": "https://github.com/appuio/component-openshift4-nodes",
-      "_template": "https://github.com/projectsyn/commodore-component-template.git"
+      "_template": "https://github.com/projectsyn/commodore-component-template.git",
+      "_commit": "98d16f99766e6c6d97322dbe42e058f0e2bf73d0"
     }
   },
   "directory": null

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,6 +39,7 @@ jobs:
           - machineconfig
           - remove-machineconfigpool
           - autoscaling
+          - capacity
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}
@@ -60,6 +61,7 @@ jobs:
           - machineconfig
           - remove-machineconfigpool
           - autoscaling
+          - capacity
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}

--- a/Makefile.vars.mk
+++ b/Makefile.vars.mk
@@ -57,4 +57,4 @@ KUBENT_IMAGE    ?= ghcr.io/doitintl/kube-no-trouble:latest
 KUBENT_DOCKER   ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) --entrypoint=/app/kubent $(KUBENT_IMAGE)
 
 instance ?= defaults
-test_instances = tests/defaults.yml tests/gcp.yml tests/maxpods.yml tests/pidslimit.yml tests/machineconfig.yml tests/remove-machineconfigpool.yml tests/autoscaling.yml
+test_instances = tests/defaults.yml tests/gcp.yml tests/maxpods.yml tests/pidslimit.yml tests/machineconfig.yml tests/remove-machineconfigpool.yml tests/autoscaling.yml tests/capacity.yml

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -132,9 +132,9 @@ parameters:
     capacityAlerts:
       enabled: false
       monitorNodeRoles:
-      - app
+        - app
       monitorMachineSets:
-      - worker
+        - worker
       groupByNodeLabels: []
       groups:
         NodesPodCapacity:

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -128,3 +128,169 @@ parameters:
         registry: quay.io
         repository: appuio/oc
         tag: v4.16
+
+    capacityAlerts:
+      enabled: false
+      monitorNodeRoles:
+      - app
+      monitorMachineSets:
+      - worker
+      groupByNodeLabels: []
+      groups:
+        PodCapacity:
+          rules:
+            TooManyPods:
+              enabled: true
+              annotations:
+                message: 'Only {{ $value }} more pods can be started.'
+                runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/podcapacity.html#SYN_TooManyPods
+                description: 'The cluster is close to the limit of running pods. The cluster might not be able to handle node failures and might not be able to start new pods. Consider adding new nodes.'
+              for: 30m
+              labels: {}
+              expr:
+                # The alert specific threshold is multiplied by this factor. 1 == one node
+                factor: 1
+            ExpectTooManyPods:
+              enabled: false
+              annotations:
+                message: 'Expected to exceed the threshold of running pods in 3 days'
+                runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/podcapacity.html#SYN_ExpectTooManyPods
+                description: 'The cluster is getting close to the limit of running pods. Soon the cluster might not be able to handle node failures and might not be able to start new pods. Consider adding new nodes.'
+              for: 3h
+              labels: {}
+              expr:
+                # The alert specific threshold is multiplied by this factor. 1 == one node
+                factor: 1
+                # How much of the past to consider for the prediction
+                range: '1d'
+                # How far into the future to predict (in seconds)
+                predict: '3*24*60*60'
+
+        ResourceRequests:
+          rules:
+            TooMuchMemoryRequested:
+              enabled: true
+              annotations:
+                message: 'Only {{ $value }} memory left for new pods.'
+                runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/resourcerequests.html#SYN_TooMuchMemoryRequested
+                description: 'The cluster is close to assigning all memory to running pods. The cluster might not be able to handle node failures and might not be able to start new pods. Consider adding new nodes.'
+              for: 30m
+              labels: {}
+              expr:
+                # The alert specific threshold is multiplied by this factor. 1 == one node
+                factor: 1
+            ExpectTooMuchMemoryRequested:
+              enabled: false
+              annotations:
+                message: 'Expected to exceed the threshold of requested memory in 3 days'
+                runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/resourcerequests.html#SYN_ExpectTooMuchMemoryRequested
+                description: 'The cluster is getting close to assigning all memory to running pods. Soon the cluster might not be able to handle node failures and might not be able to start new pods. Consider adding new nodes.'
+              for: 3h
+              labels: {}
+              expr:
+                # The alert specific threshold is multiplied by this factor. 1 == one node
+                factor: 1
+                # How much of the past to consider for the prediction
+                range: '1d'
+                # How far into the future to predict (in seconds)
+                predict: '3*24*60*60'
+            TooMuchCPURequested:
+              enabled: true
+              annotations:
+                message: 'Only {{ $value }} cpu cores left for new pods.'
+                runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/resourcerequests.html#SYN_TooMuchCPURequested
+                description: 'The cluster is close to assigning all CPU resources to running pods. The cluster might not be able to handle node failures and might soon not be able to start new pods. Consider adding new nodes.'
+              for: 30m
+              labels: {}
+              expr:
+                # The alert specific threshold is multiplied by this factor. 1 == one node
+                factor: 1
+            ExpectTooMuchCPURequested:
+              enabled: false
+              annotations:
+                message: 'Expected to exceed the threshold of requested CPU resources in 3 days'
+                runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/resourcerequests.html#SYN_ExpectTooMuchCPURequested
+                description: 'The cluster is getting close to assigning all CPU cores to running pods. Soon the cluster might not be able to handle node failures and might not be able to start new pods. Consider adding new nodes.'
+              for: 3h
+              labels: {}
+              expr:
+                # The alert specific threshold is multiplied by this factor. 1 == one node
+                factor: 1
+                # How much of the past to consider for the prediction
+                range: '1d'
+                # How far into the future to predict (in seconds)
+                predict: '3*24*60*60'
+
+        MemoryCapacity:
+          rules:
+            ClusterLowOnMemory:
+              enabled: true
+              annotations:
+                message: 'Only {{ $value }} free memory on Worker Nodes.'
+                runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/memorycapacity.html#SYN_ClusterMemoryUsageHigh
+                description: 'The cluster is close to using all of its memory. The cluster might not be able to handle node failures or load spikes. Consider adding new nodes.'
+              for: 30m
+              labels: {}
+              expr:
+                # The alert specific threshold is multiplied by this factor. 1 == one node
+                factor: 1
+            ExpectClusterLowOnMemory:
+              enabled: false
+              annotations:
+                message: 'Cluster expected to run low on memory in 3 days'
+                runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/memorycapacity.html#SYN_ExpectClusterMemoryUsageHigh
+                description: 'The cluster is getting close to using all of its memory. Soon the cluster might not be able to handle node failures or load spikes. Consider adding new nodes.'
+              for: 3h
+              labels: {}
+              expr:
+                # The alert specific threshold is multiplied by this factor. 1 == one node
+                factor: 1
+                # How much of the past to consider for the prediction
+                range: '1d'
+                # How far into the future to predict (in seconds)
+                predict: '3*24*60*60'
+
+        CpuCapacity:
+          rules:
+            ClusterCpuUsageHigh:
+              enabled: true
+              annotations:
+                message: 'Only {{ $value }} idle cpu cores accross cluster.'
+                runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/cpucapacity.html#SYN_ClusterCpuUsageHigh
+                description: 'The cluster is close to using up all CPU resources. The cluster might not be able to handle node failures or load spikes. Consider adding new nodes.'
+              for: 30m
+              labels: {}
+              expr:
+                # The alert specific threshold is multiplied by this factor. 1 == one node
+                factor: 1
+
+            ExpectClusterCpuUsageHigh:
+              enabled: false
+              annotations:
+                message: 'Cluster expected to run low on available CPU resources in 3 days'
+                runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/cpucapacity.html#SYN_ExpectClusterCpuUsageHigh
+                description: 'The cluster is getting close to using up all CPU resources. The cluster might soon not be able to handle node failures or load spikes. Consider adding new nodes.'
+              for: 3h
+              labels: {}
+              expr:
+                # The alert specific threshold is multiplied by this factor. 1 == one node
+                factor: 1
+                # How much of the past to consider for the prediction
+                range: '1d'
+                # How far into the future to predict (in seconds)
+                predict: '3*24*60*60'
+
+        UnusedCapacity:
+          rules:
+            ClusterHasUnusedNodes:
+              enabled: true
+              annotations:
+                message: 'Cluster has unused nodes.'
+                runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/unusedcapacity.html#SYN_ClusterHasUnusedNodes
+                description: 'The cluster has {{ $value }} unused nodes. Consider removing unused nodes.'
+              for: 8h
+              labels: {}
+              expr:
+                # How many nodes need to be unused.
+                # There should be some overcapacity to account for failing nodes and future growth.
+                reserved: 4

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -137,7 +137,7 @@ parameters:
       - worker
       groupByNodeLabels: []
       groups:
-        PodCapacity:
+        NodesPodCapacity:
           rules:
             TooManyPods:
               enabled: true
@@ -166,7 +166,7 @@ parameters:
                 # How far into the future to predict (in seconds)
                 predict: '3*24*60*60'
 
-        ResourceRequests:
+        NodesResourceRequests:
           rules:
             TooMuchMemoryRequested:
               enabled: true
@@ -221,7 +221,7 @@ parameters:
                 # How far into the future to predict (in seconds)
                 predict: '3*24*60*60'
 
-        MemoryCapacity:
+        NodesMemoryCapacity:
           rules:
             ClusterLowOnMemory:
               enabled: true
@@ -250,7 +250,7 @@ parameters:
                 # How far into the future to predict (in seconds)
                 predict: '3*24*60*60'
 
-        CpuCapacity:
+        NodesCpuCapacity:
           rules:
             ClusterCpuUsageHigh:
               enabled: true
@@ -280,7 +280,7 @@ parameters:
                 # How far into the future to predict (in seconds)
                 predict: '3*24*60*60'
 
-        UnusedCapacity:
+        NodesUnusedCapacity:
           rules:
             ClusterHasUnusedNodes:
               enabled: true

--- a/class/openshift4-nodes.yml
+++ b/class/openshift4-nodes.yml
@@ -17,5 +17,6 @@ parameters:
           - openshift4-nodes/component/egress-interfaces.jsonnet
           - openshift4-nodes/component/autoscaler.jsonnet
           - openshift4-nodes/component/prune-machine-configs.jsonnet
+          - openshift4-nodes/component/capacity.jsonnet
         input_type: jsonnet
         output_path: openshift4-nodes/

--- a/component/capacity.jsonnet
+++ b/component/capacity.jsonnet
@@ -133,7 +133,7 @@ local podCapacityMin = adjustForAutoScaling(resourceCapacity('pods'), podCapPerN
 local podCount = aggregate(filterWorkerNodes('kubelet_running_pods'));
 
 local getExpr = function(group, rule) params.capacityAlerts.groups[group].rules[rule].expr;
-local unusedReserved = getExpr('UnusedCapacity', 'ClusterHasUnusedNodes').reserved;
+local unusedReserved = getExpr('NodesUnusedCapacity', 'ClusterHasUnusedNodes').reserved;
 
 local exprMap = {
   TooManyPods: function(arg) '%s - %s < %f * %s' % [ podCapacity, podCount, arg.factor, podCapPerNode ],

--- a/component/capacity.jsonnet
+++ b/component/capacity.jsonnet
@@ -1,0 +1,236 @@
+local monitoringOperator = import 'cluster-monitoring-operator/main.jsonnet';
+local com = import 'lib/commodore.libjsonnet';
+local kap = import 'lib/kapitan.libjsonnet';
+local kube = import 'lib/kube.libjsonnet';
+local prom = import 'lib/prom.libsonnet';
+
+local inv = kap.inventory();
+local params = inv.parameters.openshift4_nodes;
+local customAnnotations = params.capacityAlerts.customAnnotations;
+local machineSetFilter = '(%s)' % std.join('|', com.renderArray(params.capacityAlerts.monitorMachineSets));
+local nodeRoleFilter = '(%s)' % std.join('|', com.renderArray(params.capacityAlerts.monitorNodeRoles));
+
+local defaultAnnotations = {
+  syn_component: inv.parameters._instance,
+};
+
+local alertLabels = {
+  severity: 'warning',
+  syn: 'true',
+  syn_component: 'openshift4-monitoring',
+  [if std.objectHas(inv.parameters, 'syn') then 'syn_team']: std.get(inv.parameters.syn, 'owner', ''),
+};
+
+local useMachineSets =
+  std.length(params.nodeGroups) > 0 || std.length(params.machineSets) > 0;
+
+local byLabels =
+  [ 'role' ] + com.renderArray(params.capacityAlerts.groupByNodeLabels);
+
+local hasAutoScaling =
+  params.autoscaling.enabled;
+
+local predict(indicator, range='1d', resolution='5m', predict='3*24*60*60') =
+  'predict_linear(avg_over_time(%(indicator)s[%(range)s:%(resolution)s])[%(range)s:%(resolution)s], %(predict)s)' %
+  { indicator: indicator, range: range, resolution: resolution, predict: predict };
+
+
+local addNodeLabels(metric) =
+  if std.length(byLabels) > 0 then
+    '%(metric)s * on(node) group_left(%(labelList)s) kube_node_labels' %
+    { metric: metric, labelList: std.join(', ', byLabels) }
+  else
+    metric;
+
+local addMachineSets(metric) =
+  '%(metric)s * on(node) group_left(%(labelList)s) label_replace(openshift_upgrade_controller_machine_info, "node", "$1", "node_ref", "(.+)")' %
+  { metric: metric, labelList: 'machineset' };
+
+local renameNodeLabel(expression, nodeLabel) =
+  if nodeLabel == 'node' then
+    expression
+  else
+    'label_replace(%(expression)s, "node", "$1", "%(nodeLabel)s", "(.+)")' %
+    { expression: expression, nodeLabel: nodeLabel };
+
+local filterWorkerNodesByMachineSet(metric, machineSetFilter=machineSetFilter, nodeLabel='node') =
+  '%(metric)s * on(node) group_left(machineset) label_replace(openshift_upgrade_controller_machine_info{machineset=~"%(machineSetFilter)s"}, "node", "$1", "node_ref", "(.+)")' %
+  { metric: renameNodeLabel(metric, nodeLabel), nodeLabel: nodeLabel, machineSetFilter: machineSetFilter }
+;
+
+local filterWorkerNodesByRole(metric, workerRole=nodeRoleFilter, nodeLabel='node') =
+  addNodeLabels(
+    '%(metric)s * on(node) group_left kube_node_role{role=~"%(workerRole)s"}' %
+    { metric: renameNodeLabel(metric, nodeLabel), nodeLabel: nodeLabel, workerRole: workerRole }
+  );
+
+local filterWorkerNodes(metric, workerIdentifier='', nodeLabel='node') =
+  if useMachineSets then
+    filterWorkerNodesByMachineSet(metric, (if workerIdentifier != '' then workerIdentifier else machineSetFilter), nodeLabel)
+  else
+    filterWorkerNodesByRole(metric, (if workerIdentifier != '' then workerIdentifier else nodeRoleFilter), nodeLabel);
+
+local aggregate(expression, aggregator='sum') =
+  if useMachineSets then
+    '%(aggregator)s by (machineset) (%(expression)s)' %
+    { expression: expression, aggregator: aggregator }
+  else
+    if std.length(byLabels) > 0 then
+      '%(aggregator)s by (%(labelList)s) (%(expression)s)' %
+      { expression: expression, labelList: std.join(', ', byLabels), aggregator: aggregator }
+    else
+      '%(aggregator)s(%(expression)s)' %
+      { expression: expression, aggregator: aggregator };
+
+local maxPerNode(resource) =
+  if useMachineSets then
+    aggregate(addMachineSets(resource), aggregator='max')
+  else
+    aggregate(
+      addNodeLabels(
+        '(%(resource)s) * on(node) group_left kube_node_role{role=~"%(roleFilter)s"}' % { resource: resource, roleFilter: nodeRoleFilter },
+      ),
+      aggregator='max'
+    );
+
+local adjustForAutoScaling(freeResourceMetric, capacityPerNode, nodeLabel='node', direction='max') =
+  if useMachineSets then
+    if hasAutoScaling then
+      local currentNodeCountMetric = 'mapi_machine_set_status_replicas_ready';
+      local machinesetMaxSize = 'max by(machineset) (component_openshift4_monitoring_machineset_replicas_max or on(machineset) label_replace(mapi_machine_set_status_replicas_available, "machineset", "$1", "name", "(.+)"))';
+      local machinesetMinSize = 'min by(machineset) (component_openshift4_monitoring_machineset_replicas_min or on(machineset) label_replace(mapi_machine_set_status_replicas_available, "machineset", "$1", "name", "(.+)"))';
+      local currentNodeCountMetric = 'label_replace(mapi_machine_set_status_replicas_available, "machineset", "$1", "name", "(.+)")';
+      '%(metric)s + on(machineset) (%(minOrMax)s - on(machineset) %(currentNodeCount)s) * on(machineset) %(capacityPerNode)s' %
+      { metric: freeResourceMetric, nodeLabel: nodeLabel, minOrMax: if direction == 'max' then machinesetMaxSize else machinesetMinSize, currentNodeCount: currentNodeCountMetric, capacityPerNode: capacityPerNode }
+    else
+      freeResourceMetric
+  else
+    freeResourceMetric;
+
+local resourceCapacity(resource) = aggregate(filterWorkerNodes('kube_node_status_capacity{resource="%s"}' % resource));
+local resourceAllocatable(resource) = aggregate(filterWorkerNodes('kube_node_status_allocatable{resource="%s"}' % resource));
+local resourceRequests(resource) = aggregate(filterWorkerNodes('kube_pod_resource_request{resource="%s"}' % resource));
+
+local memoryRequestsCapPerNode = maxPerNode('kube_node_status_allocatable{resource="memory"}');
+local memoryCapPerNode = maxPerNode('kube_node_status_capacity{resource="memory"}');
+local memoryAllocatable = adjustForAutoScaling(resourceAllocatable('memory'), memoryRequestsCapPerNode);
+local memoryAllocatableMin = adjustForAutoScaling(resourceAllocatable('memory'), memoryRequestsCapPerNode, direction='min');
+local memoryRequests = resourceRequests('memory');
+local memoryFree = adjustForAutoScaling(aggregate(filterWorkerNodes('node_memory_MemAvailable_bytes', nodeLabel='instance')), memoryCapPerNode);
+local memoryFreeMin = adjustForAutoScaling(aggregate(filterWorkerNodes('node_memory_MemAvailable_bytes', nodeLabel='instance')), memoryCapPerNode, direction='min');
+
+local cpuRequestsCapPerNode = maxPerNode('kube_node_status_allocatable{resource="cpu"}');
+local cpuCapPerNode = maxPerNode('kube_node_status_capacity{resource="cpu"}');
+local cpuAllocatable = adjustForAutoScaling(resourceAllocatable('cpu'), cpuRequestsCapPerNode);
+local cpuAllocatableMin = adjustForAutoScaling(resourceAllocatable('cpu'), cpuRequestsCapPerNode, direction='min');
+local cpuRequests = resourceRequests('cpu');
+local cpuIdle = adjustForAutoScaling(aggregate(filterWorkerNodes('rate(node_cpu_seconds_total{mode="idle"}[15m])', nodeLabel='instance')), cpuCapPerNode);
+local cpuIdleMin = adjustForAutoScaling(aggregate(filterWorkerNodes('rate(node_cpu_seconds_total{mode="idle"}[15m])', nodeLabel='instance')), cpuCapPerNode, direction='min');
+
+local podCapPerNode = maxPerNode('kube_node_status_capacity{resource="pods"}');
+local podCapacity = adjustForAutoScaling(resourceCapacity('pods'), podCapPerNode);
+local podCapacityMin = adjustForAutoScaling(resourceCapacity('pods'), podCapPerNode, direction='min');
+local podCount = aggregate(filterWorkerNodes('kubelet_running_pods'));
+
+local getExpr = function(group, rule) params.capacityAlerts.groups[group].rules[rule].expr;
+local unusedReserved = getExpr('UnusedCapacity', 'ClusterHasUnusedNodes').reserved;
+
+local exprMap = {
+  TooManyPods: function(arg) '%s - %s < %f * %s' % [ podCapacity, podCount, arg.factor, podCapPerNode ],
+  ExpectTooManyPods: function(arg) '%s - %s < %f * %s' % [ podCapacity, predict(podCount, range=arg.range, predict=arg.predict), arg.factor, podCapPerNode ],
+
+  TooMuchMemoryRequested: function(arg) '%s - %s < %f * %s' % [ memoryAllocatable, memoryRequests, arg.factor, memoryRequestsCapPerNode ],
+  ExpectTooMuchMemoryRequested: function(arg) '%s - %s < %f * %s' % [ memoryAllocatable, predict(memoryRequests, range=arg.range, predict=arg.predict), arg.factor, memoryRequestsCapPerNode ],
+  TooMuchCPURequested: function(arg) '%s - %s < %f * %s' % [ cpuAllocatable, cpuRequests, arg.factor, cpuRequestsCapPerNode ],
+  ExpectTooMuchCPURequested: function(arg) '%s - %s < %f * %s' % [ cpuAllocatable, predict(cpuRequests, range=arg.range, predict=arg.predict), arg.factor, cpuRequestsCapPerNode ],
+
+  ClusterLowOnMemory: function(arg) '%s < %f * %s' % [ memoryFree, arg.factor, memoryCapPerNode ],
+  ExpectClusterLowOnMemory: function(arg) '%s < %f * %s' % [ predict(memoryFree, range=arg.range, predict=arg.predict), arg.factor, memoryCapPerNode ],
+
+  ClusterCpuUsageHigh: function(arg) '%s < %f * %s' % [ cpuIdle, arg.factor, cpuCapPerNode ],
+  ExpectClusterCpuUsageHigh: function(arg) '%s < %f * %s' % [ predict(cpuIdle, range=arg.range, predict=arg.predict), arg.factor, cpuCapPerNode ],
+
+  ClusterHasUnusedNodes: function(arg)
+    '%s > %f' % [
+      aggregate(
+        |||
+          (
+            label_replace(
+              (%s - %s) / %s
+            , "resource", "pods", "", "")
+          ) or (
+            label_replace(
+              (%s - %s) / %s
+            , "resource", "requested_memory", "", "")
+          ) or (
+            label_replace(
+              (%s - %s) / %s
+            , "resource", "requested_cpu", "", "")
+          ) or (
+            label_replace(
+              %s / %s
+            , "resource", "memory", "", "")
+          ) or (
+            label_replace(
+              %s / %s
+            , "resource", "cpu", "", "")
+          )
+        ||| %
+        [
+          podCapacityMin,
+          podCount,
+          podCapPerNode,
+
+          memoryAllocatableMin,
+          memoryRequests,
+          memoryRequestsCapPerNode,
+
+          cpuAllocatableMin,
+          cpuRequests,
+          cpuRequestsCapPerNode,
+
+          memoryFreeMin,
+          memoryCapPerNode,
+
+          cpuIdleMin,
+          cpuCapPerNode,
+        ],
+
+        'min'
+      ),
+      unusedReserved,
+    ],
+};
+
+{
+  [if params.capacityAlerts.enabled then 'capacity_alerting_rules']: prom.PrometheusRule('openshift4-nodes-capacity') {
+    metadata+: {
+      annotations+: defaultAnnotations,
+      namespace: inv.parameters.openshift4_monitoring.namespace,
+    },
+    spec+: {
+      groups: std.filter(function(x) std.length(x.rules) > 0, [
+        {
+          local group = params.capacityAlerts.groups[alertGroupName],
+          name: 'syn-' + alertGroupName,
+          rules: [
+            group.rules[ruleName] {
+              alert: 'SYN_' + ruleName,
+              enabled:: true,
+              labels: alertLabels + super.labels,
+              annotations: defaultAnnotations + super.annotations,
+              expr:
+                if std.objectHas(super.expr, 'raw') then
+                  super.expr.raw
+                else
+                  exprMap[ruleName](super.expr),
+            }
+            for ruleName in std.objectFields(group.rules)
+            if group.rules[ruleName].enabled
+          ],
+        }
+        for alertGroupName in std.objectFields(params.capacityAlerts.groups)
+      ]),
+    },
+  },
+}

--- a/docs/modules/ROOT/pages/explanations/resource_management.adoc
+++ b/docs/modules/ROOT/pages/explanations/resource_management.adoc
@@ -1,0 +1,299 @@
+= Resource Management
+
+This component can introduce multiple alerts that should notify you if the cluster is about to run out of resources and needs additional nodes.
+The provided alerts focus only on worker nodes by default, and aim to always be actionable.
+
+== Resource Management and Autoscaling
+If autoscaling is enabled for a machineset, capacity alerts are only actionable if the cluster has already reached its autoscaling limit.
+The generated alert rules account for this by comparing current utilization to the capacity on the cluster that would be available if it were fully scaled up.
+
+Similarly, the alert for unused nodes takes autoscaling into account by comparing utilization to the capacity that would be available if the cluster were fully scaled down, and alerting only if there would still be unused nodes at that point.
+
+For these mechanisms to work, it is necessary that the parameter `autoscaling.customMetrics.enabled` is set to `true`.
+If this is not the case, the alerts will compare utilization only to the capacity of the nodes currently online, which can lead to non-actionable alerts.
+
+
+== Indicators
+
+=== Pod Count
+
+A high pod count is a good indicator that we need to add more worker nodes.
+It's only recommended to run up to 110 pods per node.
+Additional pods are unable to be scheduled.
+
+The component provides two pod count related alerts:
+
+.**Too many pods**
+
+We alert if we're unable to run all currently running pods if the largest worker node crashes.
+
+```
+// The pod capacity of all worker nodes
+sum(
+  kube_node_status_capacity{resource="pods"}
+    * on(node) group_left kube_node_role{role="app"}
+)
+-
+// The number of running pods on all worker nodes
+sum(
+  kubelet_running_pods
+    * on(node) group_left kube_node_role{role="app"},
+)
+<
+// The pod capacity of the largest worker node
+max(
+  kube_node_status_capacity{resource="pods"}
+    * on(node) group_left kube_node_role{role="app"}
+)
+```
+
+.**Expect too many pods**
+
+We alert if we predict that we'll be unable to run all pods if the largest worker node crashes in three days, assuming linear growth of running pods based on the change in running pods over the last 24 hours.
+```
+// The pod capacity of all worker nodes
+sum(
+  kube_node_status_capacity{resource="pods"}
+    * on(node) group_left kube_node_role{role="app"}
+)
+-
+// The predicted number of running pods on all worker nodes in 3 days
+predict_linear(
+  // Take the moving average over a day to prevent flapping alerts
+  avg_over_time(
+    sum(
+      kubelet_running_pods
+        * on(node) group_left kube_node_role{role="app"},
+    )[1d:1h]
+  )[1d:1h],
+3*24*60*60)
+<
+// The pod capacity of the largest worker node
+max(
+  kube_node_status_capacity{resource="pods"}
+    * on(node) group_left kube_node_role{role="app"}
+)
+```
+
+=== Memory/CPU requests
+
+The combined memory and CPU requests of all workloads is another good indicator.
+If the combined requests are higher than the actual resources, some workloads will no be scheduled.
+
+The component provides four resource request related alerts.
+They alert if there isn't enough CPU or memory capacity if the largest worker node disappears or if we predict that the cluster will exceed this threshold in three days.
+
+.**Too much memory requested**
+```
+// The allocatable memory on all worker nodes
+sum(
+  kube_node_status_allocatable{resource="memory"}
+    * on(node) group_left kube_node_role{role="app"}
+)
+-
+// The memory requests on all worker nodes
+sum(
+  kube_pod_resource_request{resource="memory"}
+    * on(node) group_left kube_node_role{role="app"}
+)
+<
+// The allocatable memory on the largest worker node
+max(
+  kube_node_status_allocatable{resource="memory"}
+    * on(node) group_left kube_node_role{role="app"}
+)
+```
+.**Expect too much memory to be requested**
+```
+// The allocatable memory on all worker nodes
+sum(
+  kube_node_status_allocatable{resource="memory"}
+    * on(node) group_left kube_node_role{role="app"}
+)
+-
+// The predicted memory requests on all worker nodes in three days
+predict_linear(
+  avg_over_time(
+    sum(
+      kube_pod_resource_request{resource="memory"}
+        * on(node) group_left kube_node_role{role="app"}
+    )[1d:1h]
+  )[1d:1h],
+3*24*60*60)
+<
+// The allocatable memory on the largest worker node
+max(
+  kube_node_status_allocatable{resource="memory"}
+    * on(node) group_left kube_node_role{role="app"}
+)
+```
+
+.**Too much CPU requested**
+```
+// The allocatable CPU cores on all worker nodes
+sum(
+  kube_node_status_allocatable{resource="cpu"}
+    * on(node) group_left kube_node_role{role="app"}
+)
+-
+// The CPU requests on all worker nodes
+sum(
+  kube_pod_resource_request{resource="cpu"}
+    * on(node) group_left kube_node_role{role="app"}
+)
+<
+// The allocatable CPU cores on largest worker node
+max(
+  kube_node_status_allocatable{resource="cpu"}
+    * on(node) group_left kube_node_role{role="app"}
+)
+```
+.**Expect too much CPU to be requested**
+```
+// The allocatable CPU cores on all worker nodes
+sum(
+  kube_node_status_allocatable{resource="cpu"}
+    * on(node) group_left kube_node_role{role="app"}
+)
+-
+// The predicted CPU requests on all worker nodes in three days
+predict_linear(
+  avg_over_time(
+    sum(
+      kube_pod_resource_request{resource="cpu"}
+        * on(node) group_left kube_node_role{role="app"}
+    )[1d:1h]
+  )[1d:1h],
+3*24*60*60)
+<
+// The allocatable CPU cores on largest worker node
+max(
+  kube_node_status_allocatable{resource="cpu"}
+    * on(node) group_left kube_node_role{role="app"}
+)
+```
+
+=== Memory Usage
+
+Low available memory is a good indicator that the cluster needs to be resized.
+If there is no available memory, the cluster won't be able to schedule new workload and will eventually start to OOM kill workloads
+
+The component provides two memory usage related alerts:
+
+.**Workers low on memory memory**
+
+We alert if there is less memory available than the largest worker node.
+
+```
+sum(
+  // The unused memory for every node with role "app"
+  node_memory_MemAvailable_bytes
+    * on(instance) group_left label_replace(kube_node_role{role="app"}, "instance", "$1", "node", "(.+)")
+)
+<
+// The capacity of the largest worker node
+max(kube_node_status_capacity{resource="memory"}
+  * on(node) group_left kube_node_role{role="app"})
+```
+
+.**Workers expected run out of memory**
+
+We alert if we expect that in three days less memory will be available than the largest worker node.
+
+```
+
+// Predict in 3 days
+predict_linear(
+  // Take the moving average over a day to prevent flapping alerts
+  avg_over_time(
+    sum(
+      // The unused memory for every node with role "app"
+      node_memory_MemAvailable_bytes *
+          on(instance) group_left label_replace(kube_node_role{role="app"}, "instance", "$1", "node", "(.+)")
+    )[1d:1h]
+  )[1d:1h],
+3*24*60*60)
+<
+// The capacity of the largest worker node
+max(
+  kube_node_status_capacity{resource="memory"}
+    * on(node) group_left kube_node_role{role="app"}
+  )
+```
+
+
+=== CPU Usage
+
+High CPU usage can also be an indicator that the cluster is too small.
+
+The component provides two CPU usage related alerts:
+
+.**Workers CPU usage high**
+We alert if there is fewer idle CPU cores than the largest worker node has.
+```
+sum(
+  // The average number of idle CPUs over 15 minutes for all worker nodes
+  rate(node_cpu_seconds_total{mode="idle"}[15m])
+    * on(instance) group_left label_replace(kube_node_role{role="app"}, "instance", "$1", "node", "(.+)"))
+<
+// The capacity of the largest worker node
+max(
+  kube_node_status_capacity{resource="cpu"}
+    * on(node) group_left kube_node_role{role="app"}
+)
+```
+
+.**Workers CPU usage expected to be high**
+We alert if we predict to have fewer idle CPU cores than the largest worker node has in three days.
+```
+// The predicted number idle CPUs for all worker nodes in 3 days
+predict_linear(
+  // Take the moving average over a day to prevent flapping alerts
+  avg_over_time(
+    sum(
+      rate(node_cpu_seconds_total{mode="idle"}[15m])
+        * on(instance) group_left label_replace(kube_node_role{role="app"}, "instance", "$1", "node", "(.+)")
+    )[1d:1h]
+  )[1d:1h],
+3*24*60*60)
+<
+// The capacity of the largest worker node
+max(
+  kube_node_status_capacity{resource="cpu"}
+    * on(node) group_left kube_node_role{role="app"}
+)
+```
+
+[NOTE]
+====
+By default, we use the one day moving average over one day for queries which predict three days into the future.
+Without the moving average the prediction is influenced too much by temporary changes.
+
+For example, if an environment is updated using a blue-green deployment, without the moving average the alert will see this sudden increase in resource usage, extrapolate the increase over three days and will fire, generating a false-positive alert.
+The moving average gives us a better indication of the long term trend.
+====
+
+== Non-Indicators
+
+There are some metrics that might be considered as an indicator for cluster capacity, but have intentionally not been added as alert rules, as they're either too noisy or not actionable.
+
+.**Memory/CPU limits**
+
+Similarly to the total memory and CPU requests of workloads one could look at the total memory and CPU limits as an indicator for cluster capacity.
+However in almost all cases the total limits are a lot higher than the actual capacity of the cluster.
+This is normal and this overprovisioning is one of the advantages of Kubernetes.
+It's hard to say what level of overprovisioning is OK and what's not, so observing the actual resource usage is more effective.
+
+.**High Node Usage / System Imbalance**
+
+We also intentionally didn't add alerts on a node level.
+It might sound like a good idea to make an alert if for example the memory of a node is maxed out.
+However such an alert isn't actionable.
+Such a _system imbalance_ can be solved by restarting pods, however Kubernetes will do this on its own eventually.
+
+.**Non Worker Node Alerts**
+
+The capacity alerts are only for the worker nodes running customer workloads.
+Monitoring system nodes is out of scope and should be handled by other alerts.
+
+The rational for this is that resource usage of system components should rarely change on its own and we very rarely should need to add additional master or infrastructure nodes.

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -679,6 +679,80 @@ For the ConfigMap data shown above the script will configure the following dummy
 * `egress_a_0` - `egress_a_31` with IPs 198.51.100.32 - 195.51.100.63 on node infra-foo.
 * `egress_a_0` - `egress_a_31` with IPs 198.51.100.64 - 195.51.100.95 on node infra-bar.
 
+== `capacityAlerts`
+
+[horizontal]
+type:: dict
+
+This parameter allows users to enable and configure alerts for node capacity management.
+The capacity alerts are disabled by default and can be enabled by setting the key `capacityAlerts.enabled` to `true`.
+Predictive alerts are disabled by default and can be enabled individually as shown below by setting `ExpectClusterCpuUsageHigh.enabled` to `true`.
+
+The dictionary will be transformed into a `PrometheusRule` object by the component.
+
+The component provides 10 alerts that are grouped in four groups.
+You can disable or modify each of these alert rules individually.
+The fields in these rules will be added to the final `PrometheusRule`, with the exception of `expr`.
+The `expr` field contains fields which can be used to tune the default alert rule.
+Alternatively, the default rule can be completely overwritten by setting the `expr.raw` field (see example below).
+See xref:explanations/resource_management.adoc[Resource Management] for an explanation for every alert rule.
+
+Nodes are grouped by machineSet if machineSets are in use on the cluster.
+If machineSets are not in use, nodes are grouped by node role instead.
+The component automatically determines whether to group by machineSets or node roles.
+
+When grouping by node role, it is possible to further group the nodes by additional node labels by specifying `capacityAlerts.groupByNodeLabels`.
+When grouping by machineSets, there is no equivalent setting.
+
+Example:
+
+[source,yaml]
+----
+capacityAlerts:
+  enabled: true <1>
+  groupByNodeLabels: [] <2>
+  monitorNodeRoles:
+   - app <3>
+  groups:
+    PodCapacity:
+      rules:
+        TooManyPods:
+          annotations:
+            message: 'The number of pods is too damn high' <4>
+          for: 3h <5>
+        ExpectTooManyPods:
+          expr: <6>
+            range: '2d'
+            predict: '5*24*60*60'
+
+    ResourceRequests:
+      rules:
+        TooMuchMemoryRequested:
+          enabled: true
+          expr:
+            raw: sum(kube_pod_resource_request{resource="memory"}) > 9000*1024*1024*1024 <7>
+    CpuCapacity:
+      rules:
+        ClusterCpuUsageHigh:
+          enabled: false <8>
+        ExpectClusterCpuUsageHigh:
+          enabled: false <8>
+    UnusedCapacity:
+      rules:
+        ClusterHasUnusedNodes:
+          enabled: false <9>
+----
+<1> Enables capacity alerts
+<2> List of node labels (as they show up in the `kube_node_labels` metric) by which alerts are grouped (only available if machineSets are not in use)
+<3> List of node roles to monitor. This is used only if machineSets are not in use. If machineSets are used, the parameter `monitorMachineSets` is used instead.
+<4> Changes the alert message for the pod capacity alert
+<5> Only alerts for pod capacity if it fires for 3 hours
+<6> Change the pod count prediction to look at the last two days and predict the value in five days
+<7> Completely overrides the default alert rule and alerts if the total memory request is over 9000 GB
+<8> Disables both CPU capacity alert rules
+<9> Disables alert if the cluster has unused nodes.
+
+
 == Example
 
 [source,yaml]

--- a/docs/modules/ROOT/partials/nav.adoc
+++ b/docs/modules/ROOT/partials/nav.adoc
@@ -2,3 +2,4 @@
 * xref:references/parameters.adoc[Parameters]
 * Explanations
 ** xref:explanations/machine-config-pool.adoc[Machine Config Pools]
+** xref:explanations/resource_management.adoc[Resource Management]

--- a/tests/autoscaling.yml
+++ b/tests/autoscaling.yml
@@ -54,3 +54,8 @@ parameters:
                   userDataSecret:
                     name: cloudscale-user-data
                   zone: rma1
+    capacityAlerts:
+      enabled: true
+      monitorMachineSets:
+      - app
+      - ~worker

--- a/tests/autoscaling.yml
+++ b/tests/autoscaling.yml
@@ -57,5 +57,5 @@ parameters:
     capacityAlerts:
       enabled: true
       monitorMachineSets:
-      - app
-      - ~worker
+        - app
+        - ~worker

--- a/tests/capacity.yml
+++ b/tests/capacity.yml
@@ -1,0 +1,3 @@
+# Overwrite parameters here
+
+# parameters: {...}

--- a/tests/capacity.yml
+++ b/tests/capacity.yml
@@ -1,3 +1,35 @@
 # Overwrite parameters here
+parameters:
+  kapitan:
+    dependencies:
+      - type: https
+        source: https://raw.githubusercontent.com/appuio/component-openshift4-monitoring/v6.8.0/lib/openshift4-monitoring-prom.libsonnet
+        output_path: vendor/lib/prom.libsonnet
+  openshift4_monitoring:
+    namespace: foo
 
-# parameters: {...}
+  openshift4_nodes:
+    capacityAlerts:
+      enabled: true
+      groupByNodeLabels:
+        - label_appuio_io_node_class
+      groups:
+        PodCapacity:
+          rules:
+            ExpectTooManyPods:
+              enabled: true
+        ResourceRequests:
+          rules:
+            ExpectTooMuchMemoryRequested:
+              enabled: true
+            ExpectTooMuchCPURequested:
+              enabled: true
+        MemoryCapacity:
+          rules:
+            ExpectClusterLowOnMemory:
+              enabled: true
+        CpuCapacity:
+          rules:
+            ExpectClusterCpuUsageHigh:
+              enabled: true
+

--- a/tests/capacity.yml
+++ b/tests/capacity.yml
@@ -14,22 +14,21 @@ parameters:
       groupByNodeLabels:
         - label_appuio_io_node_class
       groups:
-        PodCapacity:
+        NodesPodCapacity:
           rules:
             ExpectTooManyPods:
               enabled: true
-        ResourceRequests:
+        NodesResourceRequests:
           rules:
             ExpectTooMuchMemoryRequested:
               enabled: true
             ExpectTooMuchCPURequested:
               enabled: true
-        MemoryCapacity:
+        NodesMemoryCapacity:
           rules:
             ExpectClusterLowOnMemory:
               enabled: true
-        CpuCapacity:
+        NodesCpuCapacity:
           rules:
             ExpectClusterCpuUsageHigh:
               enabled: true
-

--- a/tests/golden/autoscaling/openshift4-nodes/openshift4-nodes/capacity_alerting_rules.yaml
+++ b/tests/golden/autoscaling/openshift4-nodes/openshift4-nodes/capacity_alerting_rules.yaml
@@ -1,0 +1,187 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations:
+    syn_component: openshift4-nodes
+  labels:
+    name: openshift4-nodes-capacity
+  name: openshift4-nodes-capacity
+  namespace: foo
+spec:
+  groups:
+    - name: syn-CpuCapacity
+      rules:
+        - alert: SYN_ClusterCpuUsageHigh
+          annotations:
+            description: The cluster is close to using up all CPU resources. The cluster
+              might not be able to handle node failures or load spikes. Consider adding
+              new nodes.
+            message: Only {{ $value }} idle cpu cores accross cluster.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/cpucapacity.html#SYN_ClusterCpuUsageHigh
+            syn_component: openshift4-nodes
+          expr: sum by (machineset) (label_replace(rate(node_cpu_seconds_total{mode="idle"}[15m]),
+            "node", "$1", "instance", "(.+)") * on(node) group_left(machineset) label_replace(openshift_upgrade_controller_machine_info{machineset=~"(app)"},
+            "node", "$1", "node_ref", "(.+)")) + on(machineset) (max by(machineset)
+            (component_openshift4_monitoring_machineset_replicas_max or on(machineset)
+            label_replace(mapi_machine_set_status_replicas_available, "machineset",
+            "$1", "name", "(.+)")) - on(machineset) label_replace(mapi_machine_set_status_replicas_available,
+            "machineset", "$1", "name", "(.+)")) * on(machineset) max by (machineset)
+            (kube_node_status_capacity{resource="cpu"} * on(node) group_left(machineset)
+            label_replace(openshift_upgrade_controller_machine_info, "node", "$1",
+            "node_ref", "(.+)")) < 1.000000 * max by (machineset) (kube_node_status_capacity{resource="cpu"}
+            * on(node) group_left(machineset) label_replace(openshift_upgrade_controller_machine_info,
+            "node", "$1", "node_ref", "(.+)"))
+          for: 30m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-MemoryCapacity
+      rules:
+        - alert: SYN_ClusterLowOnMemory
+          annotations:
+            description: The cluster is close to using all of its memory. The cluster
+              might not be able to handle node failures or load spikes. Consider adding
+              new nodes.
+            message: Only {{ $value }} free memory on Worker Nodes.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/memorycapacity.html#SYN_ClusterMemoryUsageHigh
+            syn_component: openshift4-nodes
+          expr: sum by (machineset) (label_replace(node_memory_MemAvailable_bytes,
+            "node", "$1", "instance", "(.+)") * on(node) group_left(machineset) label_replace(openshift_upgrade_controller_machine_info{machineset=~"(app)"},
+            "node", "$1", "node_ref", "(.+)")) + on(machineset) (max by(machineset)
+            (component_openshift4_monitoring_machineset_replicas_max or on(machineset)
+            label_replace(mapi_machine_set_status_replicas_available, "machineset",
+            "$1", "name", "(.+)")) - on(machineset) label_replace(mapi_machine_set_status_replicas_available,
+            "machineset", "$1", "name", "(.+)")) * on(machineset) max by (machineset)
+            (kube_node_status_capacity{resource="memory"} * on(node) group_left(machineset)
+            label_replace(openshift_upgrade_controller_machine_info, "node", "$1",
+            "node_ref", "(.+)")) < 1.000000 * max by (machineset) (kube_node_status_capacity{resource="memory"}
+            * on(node) group_left(machineset) label_replace(openshift_upgrade_controller_machine_info,
+            "node", "$1", "node_ref", "(.+)"))
+          for: 30m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-PodCapacity
+      rules:
+        - alert: SYN_TooManyPods
+          annotations:
+            description: The cluster is close to the limit of running pods. The cluster
+              might not be able to handle node failures and might not be able to start
+              new pods. Consider adding new nodes.
+            message: Only {{ $value }} more pods can be started.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/podcapacity.html#SYN_TooManyPods
+            syn_component: openshift4-nodes
+          expr: sum by (machineset) (kube_node_status_capacity{resource="pods"} *
+            on(node) group_left(machineset) label_replace(openshift_upgrade_controller_machine_info{machineset=~"(app)"},
+            "node", "$1", "node_ref", "(.+)")) + on(machineset) (max by(machineset)
+            (component_openshift4_monitoring_machineset_replicas_max or on(machineset)
+            label_replace(mapi_machine_set_status_replicas_available, "machineset",
+            "$1", "name", "(.+)")) - on(machineset) label_replace(mapi_machine_set_status_replicas_available,
+            "machineset", "$1", "name", "(.+)")) * on(machineset) max by (machineset)
+            (kube_node_status_capacity{resource="pods"} * on(node) group_left(machineset)
+            label_replace(openshift_upgrade_controller_machine_info, "node", "$1",
+            "node_ref", "(.+)")) - sum by (machineset) (kubelet_running_pods * on(node)
+            group_left(machineset) label_replace(openshift_upgrade_controller_machine_info{machineset=~"(app)"},
+            "node", "$1", "node_ref", "(.+)")) < 1.000000 * max by (machineset) (kube_node_status_capacity{resource="pods"}
+            * on(node) group_left(machineset) label_replace(openshift_upgrade_controller_machine_info,
+            "node", "$1", "node_ref", "(.+)"))
+          for: 30m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-ResourceRequests
+      rules:
+        - alert: SYN_TooMuchCPURequested
+          annotations:
+            description: The cluster is close to assigning all CPU resources to running
+              pods. The cluster might not be able to handle node failures and might
+              soon not be able to start new pods. Consider adding new nodes.
+            message: Only {{ $value }} cpu cores left for new pods.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/resourcerequests.html#SYN_TooMuchCPURequested
+            syn_component: openshift4-nodes
+          expr: sum by (machineset) (kube_node_status_allocatable{resource="cpu"}
+            * on(node) group_left(machineset) label_replace(openshift_upgrade_controller_machine_info{machineset=~"(app)"},
+            "node", "$1", "node_ref", "(.+)")) + on(machineset) (max by(machineset)
+            (component_openshift4_monitoring_machineset_replicas_max or on(machineset)
+            label_replace(mapi_machine_set_status_replicas_available, "machineset",
+            "$1", "name", "(.+)")) - on(machineset) label_replace(mapi_machine_set_status_replicas_available,
+            "machineset", "$1", "name", "(.+)")) * on(machineset) max by (machineset)
+            (kube_node_status_allocatable{resource="cpu"} * on(node) group_left(machineset)
+            label_replace(openshift_upgrade_controller_machine_info, "node", "$1",
+            "node_ref", "(.+)")) - sum by (machineset) (kube_pod_resource_request{resource="cpu"}
+            * on(node) group_left(machineset) label_replace(openshift_upgrade_controller_machine_info{machineset=~"(app)"},
+            "node", "$1", "node_ref", "(.+)")) < 1.000000 * max by (machineset) (kube_node_status_allocatable{resource="cpu"}
+            * on(node) group_left(machineset) label_replace(openshift_upgrade_controller_machine_info,
+            "node", "$1", "node_ref", "(.+)"))
+          for: 30m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_TooMuchMemoryRequested
+          annotations:
+            description: The cluster is close to assigning all memory to running pods.
+              The cluster might not be able to handle node failures and might not
+              be able to start new pods. Consider adding new nodes.
+            message: Only {{ $value }} memory left for new pods.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/resourcerequests.html#SYN_TooMuchMemoryRequested
+            syn_component: openshift4-nodes
+          expr: sum by (machineset) (kube_node_status_allocatable{resource="memory"}
+            * on(node) group_left(machineset) label_replace(openshift_upgrade_controller_machine_info{machineset=~"(app)"},
+            "node", "$1", "node_ref", "(.+)")) + on(machineset) (max by(machineset)
+            (component_openshift4_monitoring_machineset_replicas_max or on(machineset)
+            label_replace(mapi_machine_set_status_replicas_available, "machineset",
+            "$1", "name", "(.+)")) - on(machineset) label_replace(mapi_machine_set_status_replicas_available,
+            "machineset", "$1", "name", "(.+)")) * on(machineset) max by (machineset)
+            (kube_node_status_allocatable{resource="memory"} * on(node) group_left(machineset)
+            label_replace(openshift_upgrade_controller_machine_info, "node", "$1",
+            "node_ref", "(.+)")) - sum by (machineset) (kube_pod_resource_request{resource="memory"}
+            * on(node) group_left(machineset) label_replace(openshift_upgrade_controller_machine_info{machineset=~"(app)"},
+            "node", "$1", "node_ref", "(.+)")) < 1.000000 * max by (machineset) (kube_node_status_allocatable{resource="memory"}
+            * on(node) group_left(machineset) label_replace(openshift_upgrade_controller_machine_info,
+            "node", "$1", "node_ref", "(.+)"))
+          for: 30m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-UnusedCapacity
+      rules:
+        - alert: SYN_ClusterHasUnusedNodes
+          annotations:
+            description: The cluster has {{ $value }} unused nodes. Consider removing
+              unused nodes.
+            message: Cluster has unused nodes.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/unusedcapacity.html#SYN_ClusterHasUnusedNodes
+            syn_component: openshift4-nodes
+          expr: |-
+            min by (machineset) ((
+              label_replace(
+                (sum by (machineset) (kube_node_status_capacity{resource="pods"} * on(node) group_left(machineset) label_replace(openshift_upgrade_controller_machine_info{machineset=~"(app)"}, "node", "$1", "node_ref", "(.+)")) + on(machineset) (min by(machineset) (component_openshift4_monitoring_machineset_replicas_min or on(machineset) label_replace(mapi_machine_set_status_replicas_available, "machineset", "$1", "name", "(.+)")) - on(machineset) label_replace(mapi_machine_set_status_replicas_available, "machineset", "$1", "name", "(.+)")) * on(machineset) max by (machineset) (kube_node_status_capacity{resource="pods"} * on(node) group_left(machineset) label_replace(openshift_upgrade_controller_machine_info, "node", "$1", "node_ref", "(.+)")) - sum by (machineset) (kubelet_running_pods * on(node) group_left(machineset) label_replace(openshift_upgrade_controller_machine_info{machineset=~"(app)"}, "node", "$1", "node_ref", "(.+)"))) / max by (machineset) (kube_node_status_capacity{resource="pods"} * on(node) group_left(machineset) label_replace(openshift_upgrade_controller_machine_info, "node", "$1", "node_ref", "(.+)"))
+              , "resource", "pods", "", "")
+            ) or (
+              label_replace(
+                (sum by (machineset) (kube_node_status_allocatable{resource="memory"} * on(node) group_left(machineset) label_replace(openshift_upgrade_controller_machine_info{machineset=~"(app)"}, "node", "$1", "node_ref", "(.+)")) + on(machineset) (min by(machineset) (component_openshift4_monitoring_machineset_replicas_min or on(machineset) label_replace(mapi_machine_set_status_replicas_available, "machineset", "$1", "name", "(.+)")) - on(machineset) label_replace(mapi_machine_set_status_replicas_available, "machineset", "$1", "name", "(.+)")) * on(machineset) max by (machineset) (kube_node_status_allocatable{resource="memory"} * on(node) group_left(machineset) label_replace(openshift_upgrade_controller_machine_info, "node", "$1", "node_ref", "(.+)")) - sum by (machineset) (kube_pod_resource_request{resource="memory"} * on(node) group_left(machineset) label_replace(openshift_upgrade_controller_machine_info{machineset=~"(app)"}, "node", "$1", "node_ref", "(.+)"))) / max by (machineset) (kube_node_status_allocatable{resource="memory"} * on(node) group_left(machineset) label_replace(openshift_upgrade_controller_machine_info, "node", "$1", "node_ref", "(.+)"))
+              , "resource", "requested_memory", "", "")
+            ) or (
+              label_replace(
+                (sum by (machineset) (kube_node_status_allocatable{resource="cpu"} * on(node) group_left(machineset) label_replace(openshift_upgrade_controller_machine_info{machineset=~"(app)"}, "node", "$1", "node_ref", "(.+)")) + on(machineset) (min by(machineset) (component_openshift4_monitoring_machineset_replicas_min or on(machineset) label_replace(mapi_machine_set_status_replicas_available, "machineset", "$1", "name", "(.+)")) - on(machineset) label_replace(mapi_machine_set_status_replicas_available, "machineset", "$1", "name", "(.+)")) * on(machineset) max by (machineset) (kube_node_status_allocatable{resource="cpu"} * on(node) group_left(machineset) label_replace(openshift_upgrade_controller_machine_info, "node", "$1", "node_ref", "(.+)")) - sum by (machineset) (kube_pod_resource_request{resource="cpu"} * on(node) group_left(machineset) label_replace(openshift_upgrade_controller_machine_info{machineset=~"(app)"}, "node", "$1", "node_ref", "(.+)"))) / max by (machineset) (kube_node_status_allocatable{resource="cpu"} * on(node) group_left(machineset) label_replace(openshift_upgrade_controller_machine_info, "node", "$1", "node_ref", "(.+)"))
+              , "resource", "requested_cpu", "", "")
+            ) or (
+              label_replace(
+                sum by (machineset) (label_replace(node_memory_MemAvailable_bytes, "node", "$1", "instance", "(.+)") * on(node) group_left(machineset) label_replace(openshift_upgrade_controller_machine_info{machineset=~"(app)"}, "node", "$1", "node_ref", "(.+)")) + on(machineset) (min by(machineset) (component_openshift4_monitoring_machineset_replicas_min or on(machineset) label_replace(mapi_machine_set_status_replicas_available, "machineset", "$1", "name", "(.+)")) - on(machineset) label_replace(mapi_machine_set_status_replicas_available, "machineset", "$1", "name", "(.+)")) * on(machineset) max by (machineset) (kube_node_status_capacity{resource="memory"} * on(node) group_left(machineset) label_replace(openshift_upgrade_controller_machine_info, "node", "$1", "node_ref", "(.+)")) / max by (machineset) (kube_node_status_capacity{resource="memory"} * on(node) group_left(machineset) label_replace(openshift_upgrade_controller_machine_info, "node", "$1", "node_ref", "(.+)"))
+              , "resource", "memory", "", "")
+            ) or (
+              label_replace(
+                sum by (machineset) (label_replace(rate(node_cpu_seconds_total{mode="idle"}[15m]), "node", "$1", "instance", "(.+)") * on(node) group_left(machineset) label_replace(openshift_upgrade_controller_machine_info{machineset=~"(app)"}, "node", "$1", "node_ref", "(.+)")) + on(machineset) (min by(machineset) (component_openshift4_monitoring_machineset_replicas_min or on(machineset) label_replace(mapi_machine_set_status_replicas_available, "machineset", "$1", "name", "(.+)")) - on(machineset) label_replace(mapi_machine_set_status_replicas_available, "machineset", "$1", "name", "(.+)")) * on(machineset) max by (machineset) (kube_node_status_capacity{resource="cpu"} * on(node) group_left(machineset) label_replace(openshift_upgrade_controller_machine_info, "node", "$1", "node_ref", "(.+)")) / max by (machineset) (kube_node_status_capacity{resource="cpu"} * on(node) group_left(machineset) label_replace(openshift_upgrade_controller_machine_info, "node", "$1", "node_ref", "(.+)"))
+              , "resource", "cpu", "", "")
+            )
+            ) > 4.000000
+          for: 8h
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring

--- a/tests/golden/autoscaling/openshift4-nodes/openshift4-nodes/capacity_alerting_rules.yaml
+++ b/tests/golden/autoscaling/openshift4-nodes/openshift4-nodes/capacity_alerting_rules.yaml
@@ -9,7 +9,7 @@ metadata:
   namespace: foo
 spec:
   groups:
-    - name: syn-CpuCapacity
+    - name: syn-NodesCpuCapacity
       rules:
         - alert: SYN_ClusterCpuUsageHigh
           annotations:
@@ -36,7 +36,7 @@ spec:
             severity: warning
             syn: 'true'
             syn_component: openshift4-monitoring
-    - name: syn-MemoryCapacity
+    - name: syn-NodesMemoryCapacity
       rules:
         - alert: SYN_ClusterLowOnMemory
           annotations:
@@ -63,7 +63,7 @@ spec:
             severity: warning
             syn: 'true'
             syn_component: openshift4-monitoring
-    - name: syn-PodCapacity
+    - name: syn-NodesPodCapacity
       rules:
         - alert: SYN_TooManyPods
           annotations:
@@ -92,7 +92,7 @@ spec:
             severity: warning
             syn: 'true'
             syn_component: openshift4-monitoring
-    - name: syn-ResourceRequests
+    - name: syn-NodesResourceRequests
       rules:
         - alert: SYN_TooMuchCPURequested
           annotations:
@@ -148,7 +148,7 @@ spec:
             severity: warning
             syn: 'true'
             syn_component: openshift4-monitoring
-    - name: syn-UnusedCapacity
+    - name: syn-NodesUnusedCapacity
       rules:
         - alert: SYN_ClusterHasUnusedNodes
           annotations:

--- a/tests/golden/autoscaling/openshift4-nodes/openshift4-nodes/machine_autoscalers.yaml
+++ b/tests/golden/autoscaling/openshift4-nodes/openshift4-nodes/machine_autoscalers.yaml
@@ -1,11 +1,13 @@
 apiVersion: autoscaling.openshift.io/v1beta1
 kind: MachineAutoscaler
+maxReplicas: 6
 metadata:
   annotations: {}
   labels:
     name: app
   name: app
   namespace: openshift-machine-api
+minReplicas: 3
 spec:
   maxReplicas: 6
   minReplicas: 3

--- a/tests/golden/autoscaling/openshift4-nodes/openshift4-nodes/machine_autoscalers.yaml
+++ b/tests/golden/autoscaling/openshift4-nodes/openshift4-nodes/machine_autoscalers.yaml
@@ -1,13 +1,11 @@
 apiVersion: autoscaling.openshift.io/v1beta1
 kind: MachineAutoscaler
-maxReplicas: 6
 metadata:
   annotations: {}
   labels:
     name: app
   name: app
   namespace: openshift-machine-api
-minReplicas: 3
 spec:
   maxReplicas: 6
   minReplicas: 3

--- a/tests/golden/capacity/openshift4-nodes/apps/openshift4-nodes.yaml
+++ b/tests/golden/capacity/openshift4-nodes/apps/openshift4-nodes.yaml
@@ -1,0 +1,5 @@
+spec:
+  ignoreDifferences: []
+  syncPolicy:
+    syncOptions:
+      - RespectIgnoreDifferences=true

--- a/tests/golden/capacity/openshift4-nodes/openshift4-nodes/01_aggregated_clusterroles.yaml
+++ b/tests/golden/capacity/openshift4-nodes/openshift4-nodes/01_aggregated_clusterroles.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: syn-openshift4-nodes-cluster-reader
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: 'true'
+  name: syn-openshift4-nodes-cluster-reader
+rules:
+  - apiGroups:
+      - machineconfiguration.openshift.io
+    resources:
+      - machineconfigs
+    verbs:
+      - get
+      - list
+      - watch

--- a/tests/golden/capacity/openshift4-nodes/openshift4-nodes/10_kubeletconfigs.yaml
+++ b/tests/golden/capacity/openshift4-nodes/openshift4-nodes/10_kubeletconfigs.yaml
@@ -1,0 +1,17 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: openshift4-nodes
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: openshift4-nodes
+    name: workers
+  name: workers
+spec:
+  kubeletConfig:
+    maxPods: 110
+  machineConfigPoolSelector:
+    matchExpressions:
+      - key: pools.operator.machineconfiguration.openshift.io/worker
+        operator: Exists

--- a/tests/golden/capacity/openshift4-nodes/openshift4-nodes/10_nodeconfig.yaml
+++ b/tests/golden/capacity/openshift4-nodes/openshift4-nodes/10_nodeconfig.yaml
@@ -1,0 +1,12 @@
+apiVersion: config.openshift.io/v1
+kind: Node
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: openshift4-nodes
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: openshift4-nodes
+    name: cluster
+  name: cluster
+spec:
+  cgroupMode: v1

--- a/tests/golden/capacity/openshift4-nodes/openshift4-nodes/capacity_alerting_rules.yaml
+++ b/tests/golden/capacity/openshift4-nodes/openshift4-nodes/capacity_alerting_rules.yaml
@@ -1,0 +1,264 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations:
+    syn_component: openshift4-nodes
+  labels:
+    name: openshift4-nodes-capacity
+  name: openshift4-nodes-capacity
+  namespace: foo
+spec:
+  groups:
+    - name: syn-CpuCapacity
+      rules:
+        - alert: SYN_ClusterCpuUsageHigh
+          annotations:
+            description: The cluster is close to using up all CPU resources. The cluster
+              might not be able to handle node failures or load spikes. Consider adding
+              new nodes.
+            message: Only {{ $value }} idle cpu cores accross cluster.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/cpucapacity.html#SYN_ClusterCpuUsageHigh
+            syn_component: openshift4-nodes
+          expr: sum by (role, label_appuio_io_node_class) (label_replace(rate(node_cpu_seconds_total{mode="idle"}[15m]),
+            "node", "$1", "instance", "(.+)") * on(node) group_left kube_node_role{role=~"(app)"}
+            * on(node) group_left(role, label_appuio_io_node_class) kube_node_labels)
+            < 1.000000 * max by (role, label_appuio_io_node_class) ((kube_node_status_capacity{resource="cpu"})
+            * on(node) group_left kube_node_role{role=~"(app)"} * on(node) group_left(role,
+            label_appuio_io_node_class) kube_node_labels)
+          for: 30m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_ExpectClusterCpuUsageHigh
+          annotations:
+            description: The cluster is getting close to using up all CPU resources.
+              The cluster might soon not be able to handle node failures or load spikes.
+              Consider adding new nodes.
+            message: Cluster expected to run low on available CPU resources in 3 days
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/cpucapacity.html#SYN_ExpectClusterCpuUsageHigh
+            syn_component: openshift4-nodes
+          expr: predict_linear(avg_over_time(sum by (role, label_appuio_io_node_class)
+            (label_replace(rate(node_cpu_seconds_total{mode="idle"}[15m]), "node",
+            "$1", "instance", "(.+)") * on(node) group_left kube_node_role{role=~"(app)"}
+            * on(node) group_left(role, label_appuio_io_node_class) kube_node_labels)[1d:5m])[1d:5m],
+            3*24*60*60) < 1.000000 * max by (role, label_appuio_io_node_class) ((kube_node_status_capacity{resource="cpu"})
+            * on(node) group_left kube_node_role{role=~"(app)"} * on(node) group_left(role,
+            label_appuio_io_node_class) kube_node_labels)
+          for: 3h
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-MemoryCapacity
+      rules:
+        - alert: SYN_ClusterLowOnMemory
+          annotations:
+            description: The cluster is close to using all of its memory. The cluster
+              might not be able to handle node failures or load spikes. Consider adding
+              new nodes.
+            message: Only {{ $value }} free memory on Worker Nodes.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/memorycapacity.html#SYN_ClusterMemoryUsageHigh
+            syn_component: openshift4-nodes
+          expr: sum by (role, label_appuio_io_node_class) (label_replace(node_memory_MemAvailable_bytes,
+            "node", "$1", "instance", "(.+)") * on(node) group_left kube_node_role{role=~"(app)"}
+            * on(node) group_left(role, label_appuio_io_node_class) kube_node_labels)
+            < 1.000000 * max by (role, label_appuio_io_node_class) ((kube_node_status_capacity{resource="memory"})
+            * on(node) group_left kube_node_role{role=~"(app)"} * on(node) group_left(role,
+            label_appuio_io_node_class) kube_node_labels)
+          for: 30m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_ExpectClusterLowOnMemory
+          annotations:
+            description: The cluster is getting close to using all of its memory.
+              Soon the cluster might not be able to handle node failures or load spikes.
+              Consider adding new nodes.
+            message: Cluster expected to run low on memory in 3 days
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/memorycapacity.html#SYN_ExpectClusterMemoryUsageHigh
+            syn_component: openshift4-nodes
+          expr: predict_linear(avg_over_time(sum by (role, label_appuio_io_node_class)
+            (label_replace(node_memory_MemAvailable_bytes, "node", "$1", "instance",
+            "(.+)") * on(node) group_left kube_node_role{role=~"(app)"} * on(node)
+            group_left(role, label_appuio_io_node_class) kube_node_labels)[1d:5m])[1d:5m],
+            3*24*60*60) < 1.000000 * max by (role, label_appuio_io_node_class) ((kube_node_status_capacity{resource="memory"})
+            * on(node) group_left kube_node_role{role=~"(app)"} * on(node) group_left(role,
+            label_appuio_io_node_class) kube_node_labels)
+          for: 3h
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-PodCapacity
+      rules:
+        - alert: SYN_ExpectTooManyPods
+          annotations:
+            description: The cluster is getting close to the limit of running pods.
+              Soon the cluster might not be able to handle node failures and might
+              not be able to start new pods. Consider adding new nodes.
+            message: Expected to exceed the threshold of running pods in 3 days
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/podcapacity.html#SYN_ExpectTooManyPods
+            syn_component: openshift4-nodes
+          expr: sum by (role, label_appuio_io_node_class) (kube_node_status_capacity{resource="pods"}
+            * on(node) group_left kube_node_role{role=~"(app)"} * on(node) group_left(role,
+            label_appuio_io_node_class) kube_node_labels) - predict_linear(avg_over_time(sum
+            by (role, label_appuio_io_node_class) (kubelet_running_pods * on(node)
+            group_left kube_node_role{role=~"(app)"} * on(node) group_left(role, label_appuio_io_node_class)
+            kube_node_labels)[1d:5m])[1d:5m], 3*24*60*60) < 1.000000 * max by (role,
+            label_appuio_io_node_class) ((kube_node_status_capacity{resource="pods"})
+            * on(node) group_left kube_node_role{role=~"(app)"} * on(node) group_left(role,
+            label_appuio_io_node_class) kube_node_labels)
+          for: 3h
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_TooManyPods
+          annotations:
+            description: The cluster is close to the limit of running pods. The cluster
+              might not be able to handle node failures and might not be able to start
+              new pods. Consider adding new nodes.
+            message: Only {{ $value }} more pods can be started.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/podcapacity.html#SYN_TooManyPods
+            syn_component: openshift4-nodes
+          expr: sum by (role, label_appuio_io_node_class) (kube_node_status_capacity{resource="pods"}
+            * on(node) group_left kube_node_role{role=~"(app)"} * on(node) group_left(role,
+            label_appuio_io_node_class) kube_node_labels) - sum by (role, label_appuio_io_node_class)
+            (kubelet_running_pods * on(node) group_left kube_node_role{role=~"(app)"}
+            * on(node) group_left(role, label_appuio_io_node_class) kube_node_labels)
+            < 1.000000 * max by (role, label_appuio_io_node_class) ((kube_node_status_capacity{resource="pods"})
+            * on(node) group_left kube_node_role{role=~"(app)"} * on(node) group_left(role,
+            label_appuio_io_node_class) kube_node_labels)
+          for: 30m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-ResourceRequests
+      rules:
+        - alert: SYN_ExpectTooMuchCPURequested
+          annotations:
+            description: The cluster is getting close to assigning all CPU cores to
+              running pods. Soon the cluster might not be able to handle node failures
+              and might not be able to start new pods. Consider adding new nodes.
+            message: Expected to exceed the threshold of requested CPU resources in
+              3 days
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/resourcerequests.html#SYN_ExpectTooMuchCPURequested
+            syn_component: openshift4-nodes
+          expr: sum by (role, label_appuio_io_node_class) (kube_node_status_allocatable{resource="cpu"}
+            * on(node) group_left kube_node_role{role=~"(app)"} * on(node) group_left(role,
+            label_appuio_io_node_class) kube_node_labels) - predict_linear(avg_over_time(sum
+            by (role, label_appuio_io_node_class) (kube_pod_resource_request{resource="cpu"}
+            * on(node) group_left kube_node_role{role=~"(app)"} * on(node) group_left(role,
+            label_appuio_io_node_class) kube_node_labels)[1d:5m])[1d:5m], 3*24*60*60)
+            < 1.000000 * max by (role, label_appuio_io_node_class) ((kube_node_status_allocatable{resource="cpu"})
+            * on(node) group_left kube_node_role{role=~"(app)"} * on(node) group_left(role,
+            label_appuio_io_node_class) kube_node_labels)
+          for: 3h
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_ExpectTooMuchMemoryRequested
+          annotations:
+            description: The cluster is getting close to assigning all memory to running
+              pods. Soon the cluster might not be able to handle node failures and
+              might not be able to start new pods. Consider adding new nodes.
+            message: Expected to exceed the threshold of requested memory in 3 days
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/resourcerequests.html#SYN_ExpectTooMuchMemoryRequested
+            syn_component: openshift4-nodes
+          expr: sum by (role, label_appuio_io_node_class) (kube_node_status_allocatable{resource="memory"}
+            * on(node) group_left kube_node_role{role=~"(app)"} * on(node) group_left(role,
+            label_appuio_io_node_class) kube_node_labels) - predict_linear(avg_over_time(sum
+            by (role, label_appuio_io_node_class) (kube_pod_resource_request{resource="memory"}
+            * on(node) group_left kube_node_role{role=~"(app)"} * on(node) group_left(role,
+            label_appuio_io_node_class) kube_node_labels)[1d:5m])[1d:5m], 3*24*60*60)
+            < 1.000000 * max by (role, label_appuio_io_node_class) ((kube_node_status_allocatable{resource="memory"})
+            * on(node) group_left kube_node_role{role=~"(app)"} * on(node) group_left(role,
+            label_appuio_io_node_class) kube_node_labels)
+          for: 3h
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_TooMuchCPURequested
+          annotations:
+            description: The cluster is close to assigning all CPU resources to running
+              pods. The cluster might not be able to handle node failures and might
+              soon not be able to start new pods. Consider adding new nodes.
+            message: Only {{ $value }} cpu cores left for new pods.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/resourcerequests.html#SYN_TooMuchCPURequested
+            syn_component: openshift4-nodes
+          expr: sum by (role, label_appuio_io_node_class) (kube_node_status_allocatable{resource="cpu"}
+            * on(node) group_left kube_node_role{role=~"(app)"} * on(node) group_left(role,
+            label_appuio_io_node_class) kube_node_labels) - sum by (role, label_appuio_io_node_class)
+            (kube_pod_resource_request{resource="cpu"} * on(node) group_left kube_node_role{role=~"(app)"}
+            * on(node) group_left(role, label_appuio_io_node_class) kube_node_labels)
+            < 1.000000 * max by (role, label_appuio_io_node_class) ((kube_node_status_allocatable{resource="cpu"})
+            * on(node) group_left kube_node_role{role=~"(app)"} * on(node) group_left(role,
+            label_appuio_io_node_class) kube_node_labels)
+          for: 30m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_TooMuchMemoryRequested
+          annotations:
+            description: The cluster is close to assigning all memory to running pods.
+              The cluster might not be able to handle node failures and might not
+              be able to start new pods. Consider adding new nodes.
+            message: Only {{ $value }} memory left for new pods.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/resourcerequests.html#SYN_TooMuchMemoryRequested
+            syn_component: openshift4-nodes
+          expr: sum by (role, label_appuio_io_node_class) (kube_node_status_allocatable{resource="memory"}
+            * on(node) group_left kube_node_role{role=~"(app)"} * on(node) group_left(role,
+            label_appuio_io_node_class) kube_node_labels) - sum by (role, label_appuio_io_node_class)
+            (kube_pod_resource_request{resource="memory"} * on(node) group_left kube_node_role{role=~"(app)"}
+            * on(node) group_left(role, label_appuio_io_node_class) kube_node_labels)
+            < 1.000000 * max by (role, label_appuio_io_node_class) ((kube_node_status_allocatable{resource="memory"})
+            * on(node) group_left kube_node_role{role=~"(app)"} * on(node) group_left(role,
+            label_appuio_io_node_class) kube_node_labels)
+          for: 30m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-UnusedCapacity
+      rules:
+        - alert: SYN_ClusterHasUnusedNodes
+          annotations:
+            description: The cluster has {{ $value }} unused nodes. Consider removing
+              unused nodes.
+            message: Cluster has unused nodes.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/unusedcapacity.html#SYN_ClusterHasUnusedNodes
+            syn_component: openshift4-nodes
+          expr: |-
+            min by (role, label_appuio_io_node_class) ((
+              label_replace(
+                (sum by (role, label_appuio_io_node_class) (kube_node_status_capacity{resource="pods"} * on(node) group_left kube_node_role{role=~"(app)"} * on(node) group_left(role, label_appuio_io_node_class) kube_node_labels) - sum by (role, label_appuio_io_node_class) (kubelet_running_pods * on(node) group_left kube_node_role{role=~"(app)"} * on(node) group_left(role, label_appuio_io_node_class) kube_node_labels)) / max by (role, label_appuio_io_node_class) ((kube_node_status_capacity{resource="pods"}) * on(node) group_left kube_node_role{role=~"(app)"} * on(node) group_left(role, label_appuio_io_node_class) kube_node_labels)
+              , "resource", "pods", "", "")
+            ) or (
+              label_replace(
+                (sum by (role, label_appuio_io_node_class) (kube_node_status_allocatable{resource="memory"} * on(node) group_left kube_node_role{role=~"(app)"} * on(node) group_left(role, label_appuio_io_node_class) kube_node_labels) - sum by (role, label_appuio_io_node_class) (kube_pod_resource_request{resource="memory"} * on(node) group_left kube_node_role{role=~"(app)"} * on(node) group_left(role, label_appuio_io_node_class) kube_node_labels)) / max by (role, label_appuio_io_node_class) ((kube_node_status_allocatable{resource="memory"}) * on(node) group_left kube_node_role{role=~"(app)"} * on(node) group_left(role, label_appuio_io_node_class) kube_node_labels)
+              , "resource", "requested_memory", "", "")
+            ) or (
+              label_replace(
+                (sum by (role, label_appuio_io_node_class) (kube_node_status_allocatable{resource="cpu"} * on(node) group_left kube_node_role{role=~"(app)"} * on(node) group_left(role, label_appuio_io_node_class) kube_node_labels) - sum by (role, label_appuio_io_node_class) (kube_pod_resource_request{resource="cpu"} * on(node) group_left kube_node_role{role=~"(app)"} * on(node) group_left(role, label_appuio_io_node_class) kube_node_labels)) / max by (role, label_appuio_io_node_class) ((kube_node_status_allocatable{resource="cpu"}) * on(node) group_left kube_node_role{role=~"(app)"} * on(node) group_left(role, label_appuio_io_node_class) kube_node_labels)
+              , "resource", "requested_cpu", "", "")
+            ) or (
+              label_replace(
+                sum by (role, label_appuio_io_node_class) (label_replace(node_memory_MemAvailable_bytes, "node", "$1", "instance", "(.+)") * on(node) group_left kube_node_role{role=~"(app)"} * on(node) group_left(role, label_appuio_io_node_class) kube_node_labels) / max by (role, label_appuio_io_node_class) ((kube_node_status_capacity{resource="memory"}) * on(node) group_left kube_node_role{role=~"(app)"} * on(node) group_left(role, label_appuio_io_node_class) kube_node_labels)
+              , "resource", "memory", "", "")
+            ) or (
+              label_replace(
+                sum by (role, label_appuio_io_node_class) (label_replace(rate(node_cpu_seconds_total{mode="idle"}[15m]), "node", "$1", "instance", "(.+)") * on(node) group_left kube_node_role{role=~"(app)"} * on(node) group_left(role, label_appuio_io_node_class) kube_node_labels) / max by (role, label_appuio_io_node_class) ((kube_node_status_capacity{resource="cpu"}) * on(node) group_left kube_node_role{role=~"(app)"} * on(node) group_left(role, label_appuio_io_node_class) kube_node_labels)
+              , "resource", "cpu", "", "")
+            )
+            ) > 4.000000
+          for: 8h
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring

--- a/tests/golden/capacity/openshift4-nodes/openshift4-nodes/capacity_alerting_rules.yaml
+++ b/tests/golden/capacity/openshift4-nodes/openshift4-nodes/capacity_alerting_rules.yaml
@@ -9,7 +9,7 @@ metadata:
   namespace: foo
 spec:
   groups:
-    - name: syn-CpuCapacity
+    - name: syn-NodesCpuCapacity
       rules:
         - alert: SYN_ClusterCpuUsageHigh
           annotations:
@@ -50,7 +50,7 @@ spec:
             severity: warning
             syn: 'true'
             syn_component: openshift4-monitoring
-    - name: syn-MemoryCapacity
+    - name: syn-NodesMemoryCapacity
       rules:
         - alert: SYN_ClusterLowOnMemory
           annotations:
@@ -91,7 +91,7 @@ spec:
             severity: warning
             syn: 'true'
             syn_component: openshift4-monitoring
-    - name: syn-PodCapacity
+    - name: syn-NodesPodCapacity
       rules:
         - alert: SYN_ExpectTooManyPods
           annotations:
@@ -136,7 +136,7 @@ spec:
             severity: warning
             syn: 'true'
             syn_component: openshift4-monitoring
-    - name: syn-ResourceRequests
+    - name: syn-NodesResourceRequests
       rules:
         - alert: SYN_ExpectTooMuchCPURequested
           annotations:
@@ -225,7 +225,7 @@ spec:
             severity: warning
             syn: 'true'
             syn_component: openshift4-monitoring
-    - name: syn-UnusedCapacity
+    - name: syn-NodesUnusedCapacity
       rules:
         - alert: SYN_ClusterHasUnusedNodes
           annotations:

--- a/tests/golden/capacity/openshift4-nodes/openshift4-nodes/debug.yaml
+++ b/tests/golden/capacity/openshift4-nodes/openshift4-nodes/debug.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/node-selector: ''
+    scheduler.alpha.kubernetes.io/defaultTolerations: '[{"operator":"Exists"}]'
+  labels:
+    name: syn-debug-nodes
+  name: syn-debug-nodes

--- a/tests/golden/capacity/openshift4-nodes/openshift4-nodes/machineconfig_pruning.yaml
+++ b/tests/golden/capacity/openshift4-nodes/openshift4-nodes/machineconfig_pruning.yaml
@@ -1,0 +1,134 @@
+apiVersion: v1
+data:
+  machineconfig_pruning.sh: |
+    #!/bin/bash
+    set -exo pipefail
+
+    for pool in $(kubectl get machineconfigpool -ojson | jq -r '.items[].metadata.name'); do
+      oc adm prune renderedmachineconfigs list --pool-name="$pool" |\
+        grep 'in use: false' |\
+        # keep 5 newest mc
+        head -n-5 |\
+        cut -d' ' -f1 |\
+        while read -r mc; do
+          kubectl delete machineconfig "$mc"
+        done
+    done
+kind: ConfigMap
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-prune-machineconfigs
+  name: appuio-prune-machineconfigs
+  namespace: openshift-machine-config-operator
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-prune-machineconfigs
+  name: appuio-prune-machineconfigs
+  namespace: openshift-machine-config-operator
+spec:
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      completions: 1
+      parallelism: 1
+      template:
+        metadata:
+          labels:
+            name: appuio-prune-machineconfigs
+        spec:
+          containers:
+            - args: []
+              command:
+                - /scripts/machineconfig_pruning.sh
+              env:
+                - name: HOME
+                  value: /export
+              image: quay.io/appuio/oc:v4.16
+              imagePullPolicy: IfNotPresent
+              name: prune-machineconfigs
+              ports: []
+              stdin: false
+              tty: false
+              volumeMounts:
+                - mountPath: /export
+                  name: export
+                - mountPath: /scripts
+                  name: scripts
+              workingDir: /export
+          imagePullSecrets: []
+          initContainers: []
+          restartPolicy: OnFailure
+          serviceAccountName: appuio-machineconfig-pruner
+          terminationGracePeriodSeconds: 30
+          volumes:
+            - emptyDir: {}
+              name: export
+            - configMap:
+                defaultMode: 360
+                name: appuio-prune-machineconfigs
+              name: scripts
+  schedule: 0 11 * * 3
+  successfulJobsHistoryLimit: 10
+  timeZone: Europe/Zurich
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-machineconfig-pruner
+  name: appuio:machineconfig-pruner
+rules:
+  - apiGroups:
+      - machineconfiguration.openshift.io
+    resources:
+      - machineconfigs
+    verbs:
+      - get
+      - list
+      - delete
+  - apiGroups:
+      - machineconfiguration.openshift.io
+    resources:
+      - machineconfigpools
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - ''
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-machineconfig-pruner
+  name: appuio:machineconfig-pruner
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: appuio:machineconfig-pruner
+subjects:
+  - kind: ServiceAccount
+    name: appuio-machineconfig-pruner
+    namespace: openshift-machine-config-operator
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-machineconfig-pruner
+  name: appuio-machineconfig-pruner
+  namespace: openshift-machine-config-operator

--- a/tests/golden/capacity/openshift4-nodes/openshift4-nodes/machineconfigpool-app.yaml
+++ b/tests/golden/capacity/openshift4-nodes/openshift4-nodes/machineconfigpool-app.yaml
@@ -1,0 +1,23 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: openshift4-nodes
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: openshift4-nodes
+    name: x-app
+    pools.operator.machineconfiguration.openshift.io/app: ''
+  name: x-app
+spec:
+  machineConfigSelector:
+    matchExpressions:
+      - key: machineconfiguration.openshift.io/role
+        operator: In
+        values:
+          - worker
+          - x-app
+          - app
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/app: ''

--- a/tests/golden/capacity/openshift4-nodes/openshift4-nodes/machineconfigpool-infra.yaml
+++ b/tests/golden/capacity/openshift4-nodes/openshift4-nodes/machineconfigpool-infra.yaml
@@ -1,0 +1,23 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: openshift4-nodes
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: openshift4-nodes
+    name: x-infra
+    pools.operator.machineconfiguration.openshift.io/infra: ''
+  name: x-infra
+spec:
+  machineConfigSelector:
+    matchExpressions:
+      - key: machineconfiguration.openshift.io/role
+        operator: In
+        values:
+          - worker
+          - x-infra
+          - infra
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/infra: ''

--- a/tests/golden/capacity/openshift4-nodes/openshift4-nodes/machineconfigpool-storage.yaml
+++ b/tests/golden/capacity/openshift4-nodes/openshift4-nodes/machineconfigpool-storage.yaml
@@ -1,0 +1,23 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: openshift4-nodes
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: openshift4-nodes
+    name: x-storage
+    pools.operator.machineconfiguration.openshift.io/storage: ''
+  name: x-storage
+spec:
+  machineConfigSelector:
+    matchExpressions:
+      - key: machineconfiguration.openshift.io/role
+        operator: In
+        values:
+          - worker
+          - x-storage
+          - storage
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/storage: ''


### PR DESCRIPTION
The alert rules are adapted from component-openshift4-monitoring. The documentation is also blatantly yoinked from there, with only minor changes to account for the changes to alert rule configuration and behaviour.
## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
