### PR TITLE
Use correct api group to ignore cluster autoscaler difference

### DIFF
--- a/component/autoscaler.jsonnet
+++ b/component/autoscaler.jsonnet
@@ -131,7 +131,7 @@ local ignoreDifferences = [
 ] + (if std.objectHas(params.autoscaling, 'ignoreDownScalingSync')
         && params.autoscaling.ignoreDownScalingSync then [
        {
-         group: 'autoscaling.openshift.io/v1',
+         group: 'autoscaling.openshift.io',
          kind: 'ClusterAutoscaler',
          name: 'default',
          jsonPointers: [ '/spec/scaleDown/enabled' ],

--- a/tests/golden/autoscaling/openshift4-nodes/apps/openshift4-nodes.yaml
+++ b/tests/golden/autoscaling/openshift4-nodes/apps/openshift4-nodes.yaml
@@ -5,7 +5,7 @@ spec:
         - /spec/replicas
       kind: MachineSet
       name: app
-    - group: autoscaling.openshift.io/v1
+    - group: autoscaling.openshift.io
       jsonPointers:
         - /spec/scaleDown/enabled
       kind: ClusterAutoscaler


### PR DESCRIPTION


## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
