### PR TITLE
Remove pipefail bash setting in mc pruning cronjob

### DIFF
--- a/component/scripts/machineconfig_pruning.sh
+++ b/component/scripts/machineconfig_pruning.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -exo pipefail
+set -ex
 
 for pool in $(kubectl get machineconfigpool -ojson | jq -r '.items[].metadata.name'); do
   oc adm prune renderedmachineconfigs list --pool-name="$pool" |\

--- a/tests/golden/autoscaling/openshift4-nodes/openshift4-nodes/machineconfig_pruning.yaml
+++ b/tests/golden/autoscaling/openshift4-nodes/openshift4-nodes/machineconfig_pruning.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 data:
   machineconfig_pruning.sh: |
     #!/bin/bash
-    set -exo pipefail
+    set -ex
 
     for pool in $(kubectl get machineconfigpool -ojson | jq -r '.items[].metadata.name'); do
       oc adm prune renderedmachineconfigs list --pool-name="$pool" |\

--- a/tests/golden/capacity/openshift4-nodes/openshift4-nodes/machineconfig_pruning.yaml
+++ b/tests/golden/capacity/openshift4-nodes/openshift4-nodes/machineconfig_pruning.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 data:
   machineconfig_pruning.sh: |
     #!/bin/bash
-    set -exo pipefail
+    set -ex
 
     for pool in $(kubectl get machineconfigpool -ojson | jq -r '.items[].metadata.name'); do
       oc adm prune renderedmachineconfigs list --pool-name="$pool" |\

--- a/tests/golden/defaults/openshift4-nodes/openshift4-nodes/machineconfig_pruning.yaml
+++ b/tests/golden/defaults/openshift4-nodes/openshift4-nodes/machineconfig_pruning.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 data:
   machineconfig_pruning.sh: |
     #!/bin/bash
-    set -exo pipefail
+    set -ex
 
     for pool in $(kubectl get machineconfigpool -ojson | jq -r '.items[].metadata.name'); do
       oc adm prune renderedmachineconfigs list --pool-name="$pool" |\

--- a/tests/golden/gcp/openshift4-nodes/openshift4-nodes/machineconfig_pruning.yaml
+++ b/tests/golden/gcp/openshift4-nodes/openshift4-nodes/machineconfig_pruning.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 data:
   machineconfig_pruning.sh: |
     #!/bin/bash
-    set -exo pipefail
+    set -ex
 
     for pool in $(kubectl get machineconfigpool -ojson | jq -r '.items[].metadata.name'); do
       oc adm prune renderedmachineconfigs list --pool-name="$pool" |\

--- a/tests/golden/machineconfig/openshift4-nodes/openshift4-nodes/machineconfig_pruning.yaml
+++ b/tests/golden/machineconfig/openshift4-nodes/openshift4-nodes/machineconfig_pruning.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 data:
   machineconfig_pruning.sh: |
     #!/bin/bash
-    set -exo pipefail
+    set -ex
 
     for pool in $(kubectl get machineconfigpool -ojson | jq -r '.items[].metadata.name'); do
       oc adm prune renderedmachineconfigs list --pool-name="$pool" |\

--- a/tests/golden/maxpods/openshift4-nodes/openshift4-nodes/machineconfig_pruning.yaml
+++ b/tests/golden/maxpods/openshift4-nodes/openshift4-nodes/machineconfig_pruning.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 data:
   machineconfig_pruning.sh: |
     #!/bin/bash
-    set -exo pipefail
+    set -ex
 
     for pool in $(kubectl get machineconfigpool -ojson | jq -r '.items[].metadata.name'); do
       oc adm prune renderedmachineconfigs list --pool-name="$pool" |\

--- a/tests/golden/pidslimit/openshift4-nodes/openshift4-nodes/machineconfig_pruning.yaml
+++ b/tests/golden/pidslimit/openshift4-nodes/openshift4-nodes/machineconfig_pruning.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 data:
   machineconfig_pruning.sh: |
     #!/bin/bash
-    set -exo pipefail
+    set -ex
 
     for pool in $(kubectl get machineconfigpool -ojson | jq -r '.items[].metadata.name'); do
       oc adm prune renderedmachineconfigs list --pool-name="$pool" |\

--- a/tests/golden/remove-machineconfigpool/openshift4-nodes/openshift4-nodes/machineconfig_pruning.yaml
+++ b/tests/golden/remove-machineconfigpool/openshift4-nodes/openshift4-nodes/machineconfig_pruning.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 data:
   machineconfig_pruning.sh: |
     #!/bin/bash
-    set -exo pipefail
+    set -ex
 
     for pool in $(kubectl get machineconfigpool -ojson | jq -r '.items[].metadata.name'); do
       oc adm prune renderedmachineconfigs list --pool-name="$pool" |\


### PR DESCRIPTION
`grep 'in use: false'` will be empty on a fresh cluster, forcing the script to error out early with pipefail


## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
