### PR TITLE
Patch autoscaler args

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -90,6 +90,9 @@ parameters:
 
     autoscaling:
       enabled: false
+      addAutoscalerArgs:
+        - --daemonset-eviction-for-occupied-nodes=false
+        - --skip-nodes-with-local-storage=false
       clusterAutoscaler: {}
       machineAutoscalers: {}
       priorityExpanderConfig: {}

--- a/component/espejote-templates/patch-autoscaler-args.jsonnet
+++ b/component/espejote-templates/patch-autoscaler-args.jsonnet
@@ -1,0 +1,21 @@
+local esp = import 'espejote.libsonnet';
+local admission = esp.ALPHA.admission;
+
+local flagsToAdd = import 'autoscaler-inject-args/flags.json';
+
+local pod = admission.admissionRequest().object;
+
+local cids = std.find('cluster-autoscaler', std.map(function(c) c.name, pod.spec.containers));
+assert std.length(cids) == 1 : "Expected to find a single container with name 'cluster-autoscaler'";
+local containerIndex = cids[0];
+
+// Asserts against null.
+// We could just add an empty array as args before the patch and don't fail but it might be better for someone to check what changed.
+local args = std.get(pod.spec.containers[containerIndex], 'args');
+assert std.isArray(args) : 'Expected container args to be an array, is: %s' % std.type(args);
+
+local containerPath = '/spec/containers/%s' % containerIndex;
+admission.patched('added autoscaler args', admission.assertPatch(std.map(
+  function(f) admission.jsonPatchOp('add', containerPath + '/args/-', f),
+  flagsToAdd,
+)))

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -268,6 +268,26 @@ default:: `false`
 
 Whether to configure autoscaling for the cluster.
 
+=== `autoscaling.addAutoscalerArgs`
+
+[horizontal]
+type:: list
+default::
++
+[source,yaml]
+----
+addAutoscalerArgs:
+  - --daemonset-eviction-for-occupied-nodes=false
+  - --skip-nodes-with-local-storage=false
+----
+
+Patches the `default` cluster autoscaler pod with the provided arguments.
+
+Those arguments can't be set in the `ClusterAutoscaler` resource itself.
+
+* `--daemonset-eviction-for-occupied-nodes=false`: Disables eviction of DaemonSet pods to prevent CSI drivers and other required infrastructure pods from being evicted.
+* `--skip-nodes-with-local-storage=false`: Allows removing nodes with pods that use `emptyDir` volumes.
+
 === `autoscaling.ignoreDownscalingSync`
 
 [horizontal]

--- a/tests/autoscaling-scheduled.yml
+++ b/tests/autoscaling-scheduled.yml
@@ -1,9 +1,16 @@
+applications:
+  - espejote
+
 parameters:
   kapitan:
     dependencies:
       - type: https
         source: https://raw.githubusercontent.com/appuio/component-openshift4-monitoring/v6.8.0/lib/openshift4-monitoring-prom.libsonnet
         output_path: vendor/lib/prom.libsonnet
+      - type: https
+        source: https://raw.githubusercontent.com/projectsyn/component-espejote/v0.2.0/lib/espejote.libsonnet
+        output_path: vendor/lib/espejote.libsonnet
+
   openshift4_monitoring:
     namespace: foo
 

--- a/tests/autoscaling.yml
+++ b/tests/autoscaling.yml
@@ -1,9 +1,16 @@
+applications:
+  - espejote
+
 parameters:
   kapitan:
     dependencies:
       - type: https
         source: https://raw.githubusercontent.com/appuio/component-openshift4-monitoring/v6.8.0/lib/openshift4-monitoring-prom.libsonnet
         output_path: vendor/lib/prom.libsonnet
+      - type: https
+        source: https://raw.githubusercontent.com/projectsyn/component-espejote/v0.2.0/lib/espejote.libsonnet
+        output_path: vendor/lib/espejote.libsonnet
+
   openshift4_monitoring:
     namespace: foo
 

--- a/tests/golden/autoscaling/openshift4-nodes/openshift4-nodes/autoscaler_inject_args_admission.yaml
+++ b/tests/golden/autoscaling/openshift4-nodes/openshift4-nodes/autoscaler_inject_args_admission.yaml
@@ -1,0 +1,53 @@
+apiVersion: espejote.io/v1alpha1
+kind: Admission
+metadata:
+  annotations:
+    syn.tools/description: |
+      Injects autoscaler arguments to the default autoscaler pod in the openshift-machine-api namespace.
+      Arguments are taken from the a JsonnetLibrary manifest with the same name.
+
+      The patch blindly adds the arguments without trying to replace them if they already exist.
+      I debated replacing them but we won't be able to guess all upstream changes in the args array and our args parsing might fail anyways.
+      I prefer a simpler patch that fails fast to a convoluted args array merge.
+  labels:
+    app.kubernetes.io/name: autoscaler-inject-args
+  name: autoscaler-inject-args
+  namespace: openshift-machine-api
+spec:
+  mutating: true
+  template: |
+    local esp = import 'espejote.libsonnet';
+    local admission = esp.ALPHA.admission;
+
+    local flagsToAdd = import 'autoscaler-inject-args/flags.json';
+
+    local pod = admission.admissionRequest().object;
+
+    local cids = std.find('cluster-autoscaler', std.map(function(c) c.name, pod.spec.containers));
+    assert std.length(cids) == 1 : "Expected to find a single container with name 'cluster-autoscaler'";
+    local containerIndex = cids[0];
+
+    // Asserts against null.
+    // We could just add an empty array as args before the patch and don't fail but it might be better for someone to check what changed.
+    local args = std.get(pod.spec.containers[containerIndex], 'args');
+    assert std.isArray(args) : 'Expected container args to be an array, is: %s' % std.type(args);
+
+    local containerPath = '/spec/containers/%s' % containerIndex;
+    admission.patched('added autoscaler args', admission.assertPatch(std.map(
+      function(f) admission.jsonPatchOp('add', containerPath + '/args/-', f),
+      flagsToAdd,
+    )))
+  webhookConfiguration:
+    objectSelector:
+      matchLabels:
+        cluster-autoscaler: default
+        k8s-app: cluster-autoscaler
+    rules:
+      - apiGroups:
+          - ''
+        apiVersions:
+          - '*'
+        operations:
+          - CREATE
+        resources:
+          - pods

--- a/tests/golden/autoscaling/openshift4-nodes/openshift4-nodes/autoscaler_inject_args_jsonnetlibrary.yaml
+++ b/tests/golden/autoscaling/openshift4-nodes/openshift4-nodes/autoscaler_inject_args_jsonnetlibrary.yaml
@@ -1,0 +1,14 @@
+apiVersion: espejote.io/v1alpha1
+kind: JsonnetLibrary
+metadata:
+  labels:
+    app.kubernetes.io/name: autoscaler-inject-args
+  name: autoscaler-inject-args
+  namespace: openshift-machine-api
+spec:
+  data:
+    flags.json: |-
+      [
+          "--daemonset-eviction-for-occupied-nodes=false",
+          "--skip-nodes-with-local-storage=false"
+      ]


### PR DESCRIPTION
Adds some sane defaults:
- `--daemonset-eviction-for-occupied-nodes`: Stops things like CSI drivers to be evicted.
- `--skip-nodes-with-local-storage`: Allows node deletion even if pods use `emptyDir`.

Uses the espejote dynamic admission feature to patch arguments.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
