### PR TITLE
Support confguring node disruption policies

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -7,7 +7,7 @@
       "name": "OpenShift 4 Nodes",
       "slug": "openshift4-nodes",
       "parameter_key": "openshift4_nodes",
-      "test_cases": "defaults gcp maxpods pidslimit machineconfig remove-machineconfigpool autoscaling capacity",
+      "test_cases": "defaults gcp maxpods pidslimit machineconfig remove-machineconfigpool autoscaling capacity node-disruption-policies",
       "add_lib": "n",
       "add_pp": "n",
       "add_golden": "y",

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,6 +40,7 @@ jobs:
           - remove-machineconfigpool
           - autoscaling
           - capacity
+          - node-disruption-policies
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}
@@ -62,6 +63,7 @@ jobs:
           - remove-machineconfigpool
           - autoscaling
           - capacity
+          - node-disruption-policies
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}

--- a/Makefile.vars.mk
+++ b/Makefile.vars.mk
@@ -57,4 +57,4 @@ KUBENT_IMAGE    ?= ghcr.io/doitintl/kube-no-trouble:latest
 KUBENT_DOCKER   ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) --entrypoint=/app/kubent $(KUBENT_IMAGE)
 
 instance ?= defaults
-test_instances = tests/defaults.yml tests/gcp.yml tests/maxpods.yml tests/pidslimit.yml tests/machineconfig.yml tests/remove-machineconfigpool.yml tests/autoscaling.yml tests/capacity.yml
+test_instances = tests/defaults.yml tests/gcp.yml tests/maxpods.yml tests/pidslimit.yml tests/machineconfig.yml tests/remove-machineconfigpool.yml tests/autoscaling.yml tests/capacity.yml tests/node-disruption-policies.yml

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -2,6 +2,9 @@ parameters:
   openshift4_nodes:
     =_metadata:
       multi_tenant: true
+    openshiftVersion:
+      Major: '4'
+      Minor: '16'
     machineApiNamespace: openshift-machine-api
     projectName: none
     infrastructureID: none

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -132,6 +132,11 @@ parameters:
         namespace: cilium
         name: eip-shadow-ranges
 
+    nodeDisruptionPolicies:
+      files: {}
+      units: {}
+      sshkey_actions: []
+
     images:
       oc:
         registry: quay.io

--- a/class/openshift4-nodes.yml
+++ b/class/openshift4-nodes.yml
@@ -18,5 +18,6 @@ parameters:
           - openshift4-nodes/component/autoscaler.jsonnet
           - openshift4-nodes/component/prune-machine-configs.jsonnet
           - openshift4-nodes/component/capacity.jsonnet
+          - openshift4-nodes/component/node-disruption-policies.jsonnet
         input_type: jsonnet
         output_path: openshift4-nodes/

--- a/component/espejote-templates/nodedisruptionpolicies-template.jsonnet
+++ b/component/espejote-templates/nodedisruptionpolicies-template.jsonnet
@@ -1,0 +1,53 @@
+local esp = import 'espejote.libsonnet';
+local ndp = import 'nodedisruptionpolicies/ndp.libsonnet';
+
+local config = import 'nodedisruptionpolicies/config.json';
+local machineconfigs = esp.context().machineconfigs;
+
+local render_nodedisruptionpolicies() =
+  local configs = [ ndp.get_disruption_config(mc) for mc in machineconfigs ];
+  local policies =
+    {
+      files+:
+        std.get(config, 'files', []) +
+        std.flattenArrays([ std.get(dc, 'files', []) for dc in configs ]),
+      units+:
+        std.get(config, 'units', []) +
+        std.flattenArrays([ std.get(dc, 'units', []) for dc in configs ]),
+      sshkey+: {
+        actions:
+          [ std.get(config, 'sshkey_actions', []) ] +
+          [ std.get(dc, 'sshkey', { actions: [] }).actions for dc in configs ],
+      },
+    };
+  {
+    files: ndp.remove_duplicates(
+      std.sort(policies.files, keyF=function(e) e.path),
+      'path'
+    ),
+    units: ndp.remove_duplicates(
+      std.sort(policies.units, keyF=function(e) e.name),
+      'name'
+    ),
+    sshkey: { actions: ndp.select_actions(policies.sshkey.actions) },
+  };
+
+local res = {
+  apiVersion: 'operator.openshift.io/v1',
+  kind: 'MachineConfiguration',
+  metadata: {
+    name: 'cluster',
+  },
+  spec: {
+    nodeDisruptionPolicy: render_nodedisruptionpolicies(),
+  },
+};
+
+assert
+  std.length(res.spec.nodeDisruptionPolicy.files) <= 50 :
+  'Max supported length of nodeDisruptionPolicy.files is 50';
+assert
+  std.length(res.spec.nodeDisruptionPolicy.units) <= 50 :
+  'Max supported length of nodeDisruptionPolicy.units is 50';
+
+[ res ]

--- a/component/espejote-templates/nodedisruptionpolicy-helpers.libsonnet
+++ b/component/espejote-templates/nodedisruptionpolicy-helpers.libsonnet
@@ -1,0 +1,53 @@
+// get node disruption policy from machineconfig annotation
+local get_disruption_config(mc) =
+  local annotation_key = 'openshift4-nodes.syn.tools/node-disruption-policies';
+  local annotations = std.get(mc.metadata, 'annotations', {});
+  std.parseJson(std.get(annotations, annotation_key, '{}'));
+
+// Validate passed list of node disruption policy actions.
+// Currently only validates that actions lists with > 1 entry don't contain
+// `Reboot` or `None`.
+local validate_actions(actions) =
+  local valid =
+    std.length(actions) <= 1 ||
+    !(std.member(actions, { type: 'Reboot' }) || std.member(actions, { type: 'None' }));
+  assert valid : 'Actions %s is invalid' % [ actions ];
+  actions;
+
+// Selects "most disruptive" list of actions from the passed list of lists.
+// Reboot is treated as most disruptive, arbitrary other actions are
+// concatenated (TBD if this makes sense) and None is treated as least
+// disruptive.
+local select_actions(actions) = validate_actions(std.foldl(
+  function(curr, a)
+    if std.length(a) == 0 then curr
+    else if std.length(curr) == 0 then a
+    else if curr[0].type == 'Reboot' then curr
+    else if a[0].type == 'Reboot' then a
+    else if curr[0].type == 'None' then a
+    else if a[0].type == 'None' then curr
+    else curr + a,
+  actions,
+  []
+));
+
+// Removes duplicate entries from a list of policies. Should only be used for
+// `files` and `units` policy lists. For duplicate entries, the most
+// disruptive action (cf. `select_actions()` is picked for the resulting
+// entry.
+local remove_duplicates(pols, keyField) =
+  local pol_actions = std.foldl(function(res, p) res { [p[keyField]]+: [ p.actions ] }, pols, {});
+  [
+    {
+      [keyField]: k,
+      actions: select_actions(pol_actions[k]),
+    }
+    for k in std.objectFields(pol_actions)
+  ];
+
+
+{
+  get_disruption_config: get_disruption_config,
+  select_actions: select_actions,
+  remove_duplicates: remove_duplicates,
+}

--- a/component/node-disruption-policies.jsonnet
+++ b/component/node-disruption-policies.jsonnet
@@ -166,7 +166,19 @@ local managedresource =
     },
   };
 
-{
-  nodedisruptionpolicies_rbac: [ sa, cr, crb, role, rb ],
-  nodedisruptionpolicies_managedresource: [ jsonnetlib, managedresource ],
-}
+local ocpMinor = std.parseInt(params.openshiftVersion.Minor);
+
+if ocpMinor >= 17 && std.member(inv.applications, 'espejote') then
+  {
+    nodedisruptionpolicies_rbac: [ sa, cr, crb, role, rb ],
+    nodedisruptionpolicies_managedresource: [ jsonnetlib, managedresource ],
+  }
+else
+  local reason = if ocpMinor >= 17 then
+    'Espejote not installed'
+  else
+    'Node disruption policies not available on OpenShift 4.%d' % ocpMinor;
+  std.trace(
+    'Skipping configuration of node disruption policy management: %s.' % reason,
+    {}
+  )

--- a/component/node-disruption-policies.jsonnet
+++ b/component/node-disruption-policies.jsonnet
@@ -142,10 +142,18 @@ local managedresource =
     spec: {
       serviceAccountRef: { name: sa.metadata.name },
       applyOptions: { force: true },
+      context: [
+        {
+          name: 'machineconfigs',
+          resource: machineconfigs,
+        },
+      ],
       triggers: [
         {
           name: 'machineconfig',
-          watchResource: machineconfigs,
+          watchContextResource: {
+            name: 'machineconfigs',
+          },
         },
         {
           name: 'machineconfiguration/cluster',
@@ -154,12 +162,6 @@ local managedresource =
         {
           name: 'jsonnetlib',
           watchResource: jsonnetlib_ref,
-        },
-      ],
-      context: [
-        {
-          name: 'machineconfigs',
-          resource: machineconfigs,
         },
       ],
       template: importstr 'espejote-templates/nodedisruptionpolicies-template.jsonnet',

--- a/component/node-disruption-policies.jsonnet
+++ b/component/node-disruption-policies.jsonnet
@@ -1,0 +1,172 @@
+local esp = import 'lib/espejote.libsonnet';
+local kap = import 'lib/kapitan.libjsonnet';
+local kube = import 'lib/kube.libjsonnet';
+
+local inv = kap.inventory();
+local params = inv.parameters.openshift4_nodes;
+
+local namespace = 'openshift-machine-config-operator';
+
+local sa = kube.ServiceAccount('nodedisruptionpolicies-manager') {
+  metadata+: {
+    namespace: namespace,
+  },
+};
+
+local cr = kube.ClusterRole('espejote:nodedisruptionpolicies') {
+  rules: [
+    {
+      apiGroups: [ 'operator.openshift.io' ],
+      resources: [ 'machineconfigurations' ],
+      verbs: [ 'get', 'list', 'watch', 'update', 'patch' ],
+    },
+    {
+      apiGroups: [ 'machineconfiguration.openshift.io' ],
+      resources: [ 'machineconfigs' ],
+      verbs: [ 'get', 'list', 'watch' ],
+    },
+  ],
+};
+
+local crb = kube.ClusterRoleBinding('espejote:nodedisruptionpolicies') {
+  roleRef_: cr,
+  subjects_: [ sa ],
+};
+
+local role = kube.Role('espejote:nodedisruptionpolicies') {
+  metadata+: {
+    namespace: namespace,
+  },
+  rules: [
+    {
+      apiGroups: [ 'espejote.io' ],
+      resources: [ 'jsonnetlibraries' ],
+      verbs: [ 'get', 'list', 'watch' ],
+    },
+  ],
+};
+
+local rb = kube.RoleBinding('espejote:nodedisruptionpolicies') {
+  metadata+: {
+    namespace: namespace,
+  },
+  roleRef_: role,
+  subjects_: [ sa ],
+};
+
+local ndp = import
+  'espejote-templates/nodedisruptionpolicy-helpers.libsonnet';
+
+local jsonnetlib =
+  local ndp_params = params.nodeDisruptionPolicies;
+  esp.jsonnetLibrary('nodedisruptionpolicies', namespace) {
+    spec: {
+      data: {
+        'ndp.libsonnet': importstr 'espejote-templates/nodedisruptionpolicy-helpers.libsonnet',
+        'config.json': std.manifestJson({
+          files: [
+            {
+              path: f,
+              actions: ndp.select_actions([ ndp_params.files[f] ]),
+            }
+            for f in std.objectFields(ndp_params.files)
+          ],
+          units: [
+            {
+              name: u,
+              actions: ndp.select_actions([ ndp_params.units[u] ]),
+            }
+            for u in std.objectFields(ndp_params.units)
+          ],
+          sshkey_actions: ndp.select_actions([ ndp_params.sshkey_actions ]),
+        }),
+      },
+    },
+  };
+
+local machineconfigs = {
+  apiVersion: 'machineconfiguration.openshift.io/v1',
+  kind: 'MachineConfig',
+  labelSelector: {
+    matchExpressions: [ {
+      key: 'machineconfiguration.openshift.io/role',
+      operator: 'Exists',
+    } ],
+  },
+};
+local machineconfiguration_cluster = {
+  apiVersion: 'operator.openshift.io/v1',
+  kind: 'MachineConfiguration',
+};
+
+local jsonnetlib_ref = {
+  apiVersion: jsonnetlib.apiVersion,
+  kind: jsonnetlib.kind,
+  name: jsonnetlib.metadata.name,
+  namespace: jsonnetlib.metadata.namespace,
+};
+
+local managedresource =
+  esp.managedResource('nodedisruptionpolicies', namespace) {
+    metadata+: {
+      annotations: {
+        'syn.tools/description': |||
+          Manages `spec.nodeDisruptionPolicies` in the `machineconfiguration.operator/cluster` resource.
+
+          The contents of `spec.nodeDisruptionPolicies` are constructed from the
+          annotation `openshift4-nodes.syn.tools/node-disruption-policies` on all
+          non-generated MachineConfigs. We generally recommend defining very
+          specific paths for `files` disruption policies in order to avoid
+          confilicting configurations in the resulting merged config.
+
+          Any unmanaged contents of `spec.nodeDisruptionPolicies` are overwritten.
+          We explicitly execute the template when the
+          `machineconfiguration.operator/cluster` resource changes.
+
+          Generic disruption policies which are provided via Project Syn
+          parameter are provided in field `config.json` in the
+          `nodedisruptionpolicies` Espejote JsonnetLibrary resource.
+
+          NOTE: Don't configure `type: Restart` for systemd units that are managed
+          in the machineconfig resource. Doing so will cause nodes to become
+          degraded if the machineconfig is deleted.
+
+          NOTE: In general, we can't guarantee that node disruption policies
+          provided in an annotation will still be active when the machineconfig
+          is deleted. If you want to guarantee that removing a machineconfig
+          doesn't unnecessesarily reboots machines, we recommend defining
+          appropriate node disruption policies via the Project Syn hierarchy.
+        |||,
+      },
+    },
+    spec: {
+      serviceAccountRef: { name: sa.metadata.name },
+      applyOptions: { force: true },
+      triggers: [
+        {
+          name: 'machineconfig',
+          watchResource: machineconfigs,
+        },
+        {
+          name: 'machineconfiguration/cluster',
+          watchResource: machineconfiguration_cluster,
+        },
+        {
+          name: 'jsonnetlib',
+          watchResource: jsonnetlib_ref,
+        },
+      ],
+      context: [
+        {
+          name: 'machineconfigs',
+          resource: machineconfigs,
+        },
+      ],
+      template: importstr 'espejote-templates/nodedisruptionpolicies-template.jsonnet',
+    },
+  };
+
+{
+  nodedisruptionpolicies_rbac: [ sa, cr, crb, role, rb ],
+  nodedisruptionpolicies_managedresource: [ jsonnetlib, managedresource ],
+}

--- a/component/node-disruption-policies.jsonnet
+++ b/component/node-disruption-policies.jsonnet
@@ -65,16 +65,18 @@ local jsonnetlib =
         'ndp.libsonnet': importstr 'espejote-templates/nodedisruptionpolicy-helpers.libsonnet',
         'config.json': std.manifestJson({
           files: [
-            {
+            ndp_params.files[f] {
               path: f,
-              actions: ndp.select_actions([ ndp_params.files[f] ]),
+            } + {
+              actions: ndp.select_actions([ super.actions ]),
             }
             for f in std.objectFields(ndp_params.files)
           ],
           units: [
-            {
+            ndp_params.units[u] {
               name: u,
-              actions: ndp.select_actions([ ndp_params.units[u] ]),
+            } + {
+              actions: ndp.select_actions([ super.actions ]),
             }
             for u in std.objectFields(ndp_params.units)
           ],

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -10,6 +10,21 @@ Values of arrays will be appended to each other.
 There is no way to override values which were set on a lower precedence location.
 ====
 
+== `openshiftVersion`
+
+[horizontal]
+type:: dictionary
+default::
++
+[source,yaml]
+----
+Major: '4'
+Minor: '16'
+----
+
+The OpenShift version of the cluster on which the component is installed.
+We expect that most users will set this parameter to `${dynamic_facts:openshiftVersion}`.
+
 == `availabilityZones`
 
 [horizontal]
@@ -553,6 +568,14 @@ We add special support for defining file contents in the hierarchy with key `sto
 machineConfigs:
   worker-chrony-custom:
     metadata:
+      annotations:
+        openshift4-nodes.syn.tools/node-disruption-policies: |- <1>
+          {
+            "files": [{
+              "path": "/etc/chrony.conf",
+              "actions": [{"type":"Restart","restart":{"serviceName":"chronyd.service"}}]
+            }]
+          }
       labels:
         machineconfiguration.openshift.io/role: worker
     spec:
@@ -578,6 +601,8 @@ machineConfigs:
                   leapsectz right/UTC
                   logdir /var/log/chrony
 ----
+<1> Configure the machine config operator to only restart the `chronyd` service instead of draining and rebooting the node when this `MachineConfig` is applied.
+See section <<_nodedisruptionpolicies,`nodeDisruptionPolicies`>> for a full explanation of how the component supports configuring node disruption policies via annotations on `MachineConfig` resources.
 
 The resulting machine config for this example looks as follows:
 
@@ -739,6 +764,124 @@ For the ConfigMap data shown above the script will configure the following dummy
 
 * `egress_a_0` - `egress_a_31` with IPs 198.51.100.32 - 195.51.100.63 on node infra-foo.
 * `egress_a_0` - `egress_a_31` with IPs 198.51.100.64 - 195.51.100.95 on node infra-bar.
+
+== `nodeDisruptionPolicies`
+
+[horizontal]
+type:: dict
+defaults:: https://github.com/appuio/component-openshift4-nodes/blob/master/class/defaults.yml[See `class/defaults.yml`]
+
+This parameter allows configuring "static" https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/machine_configuration/machine-config-node-disruption_machine-configs-configure[node disruption policies].
+Node disruption policies allow customizing the actions that are executed when a `MachineConfig` change is applied.
+By default the machine config operator (MCO) will reboot nodes when a `MachineConfig` changes a file or a systemd unit.
+With node disruption policies, which are configured in the global `machineconfigurations.operator.openshift.io/cluster` resource, you can customize the MCO behavior when a file or systemd unit is changed.
+
+The node disruption policies are configured via field `spec.nodeDisruptionPolicy` in the `machineconfiguration.operator.openshift.io/cluster` resource.
+That object has fields `files`, `units` and `sshkey`.
+Field `files` is a list.
+Each entry of `files` has fields `path` and `actions`.
+The list is indexable by field `path` of the entries.
+Field `units` is a list.
+Each entry of `units` has fields `name` and `actions`.
+The list is indexable by field `name` of the entries.
+Field `sshkey` is an object with field `actions`.
+Field `actions` defines the actions to take when the policy matches a change.
+
+TIP: When applying policy actions, the longest prefix wins: if there are policies for both `/usr/local` and `/usr/local/bin` the policy for `/usr/local/bin` is applied for `/usr/local/bin/script.sh`.
+
+TIP: Consult `kubectl explain machineconfiguration.operator.openshift.io.spec.nodeDisruptionPolicy` for a more comprehensive explanation of each field.
+
+Actions are executed in the order that they appear in field `actions`.
+Currently, the following actions are supported:
+
+`Reboot`::
+Drains and reboots the node (the default action).
+Must occur alone.
+
+`None`::
+Does nothing.
+Must occur alone.
+
+`Drain`::
+Cordons, drains and uncordons the node.
+
+`Reload`::
+Reloads a systemd service.
+
+`Restart`::
+Restarts a systemd service.
+
+`DaemonReload`::
+Executes `systemd daemon-reload` to discover new or changed systemd configuration, such as a new systemd unit.
+
+The component expects parameter fields `files` and `units` to be dictionaries and treats the keys as values for field `path` and `name` for the `files` and `units` lists in the `MachineConfiguration` resource respectively.
+The values of each entry in `files` and `units` are used verbatim.
+The content of parameter field `sshkey_actions` is used verbatim as the contents of `sshkey.actions`.
+
+The component has some validation and will reject obviously invalid configurations, such as a list of actions which contains `Reboot` or `None` together with other actions.
+
+The component deploys an Espejote `ManagedResource` which collects node disruption policies from annotation `openshift4-nodes.syn.tools/node-disruption-policies` from all `MachineConfig` resources (except the `rendered-*` resources) and merges those values (which are expected to be string-encoded JSON) with the statically configured policies provided in this parameter.
+The contents of this parameter are deployed on the cluster in an Espejote `JsonnetLibrary` object.
+
+The contents of each annotation are expected to be string-encoded JSON which contains a valid node disruption policy snippet.
+The expected top-level fields of the annotation contents are `files`, `units` or `sshkey`.
+The `ManagedResource` uses the same validation logic as the component to reject obviously invalid configurations provided via annotations.
+
+Since there can only be one policy per file `path` and per systemd unit, the `ManagedResource` will collect each list of `actions` for a given path or unit and select the "most disruptive" list of actions.
+
+`Reboot` is treated as the most disruptive action and has precedence over all other lists of actions.
+`None` is treated as the least disruptive action and all other lists of actions have precedence over `None`.
+Other lists of actions are merged together, since we can't sensibly define an order of precedence for two lists of actions that are composed from the actions other than `None` or `Reboot`.
+
+NOTE: Node disruption policies generally won't have an effect during OpenShift upgrades.
+
+[IMPORTANT]
+====
+We can't guarantee that node disruption policies configured through `MachineConfig` annotations will still be in effect when the changes triggered by the deletion of the `MachineConfig` are rolled out.
+Therefore, we strongly recommend to configure node disruption policies that are intended to prevent machine reboots through the component parameter.
+====
+
+[IMPORTANT]
+====
+We don't recommend configuring node disruption policies which restart systemd services which themselves are deployed via `MachineConfig` objects.
+Such a node disruption policy will cause nodes to become degraded if the `MachineConfig` resource which deploys the service is removed.
+====
+
+=== Example
+
+The following configuration can be used to ensure that managing files in `/usr/local/bin` is fully non-disruptive, as long as no other configurations override this config:
+
+[source,yaml]
+----
+nodeDisruptionPolicies:
+  files:
+    "/usr/local/bin":
+      actions:
+        - None
+----
+
+The following annotations contents can be provided on a `MachineConfig` which configures a custom `/etc/chrony.conf` to just restart the chrony service instead of rebooting the node:
+
+[source,yaml]
+----
+machineConfigs: <1>
+  worker-custom-chrony: <1>
+    metadata:
+      annotations:
+        openshift4-nodes.syn.tools/node-disruption-policies: |- <2>
+          {
+            "files": [{
+              "path": "/etc/chrony.conf",
+              "actions": [{"type":"Restart","restart":{"serviceName":"chronyd.service"}}]
+            }]
+          }
+      labels:
+        machineconfiguration.openshift.io/role: worker
+    spec: { ... }
+----
+<1> We give the example via component parameter `machineConfigs`.
+See section <<_machineconfigs, `machineConfigs`>> for a full example `MachineConfig` which deploys a custom `/etc/chrony.conf`.
+<2> See the https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/machine_configuration/machine-config-node-disruption_machine-configs-configure#machine-config-node-disruption-config_machine-configs-configure[upstream documentation] for the full set of options.
 
 == `capacityAlerts`
 

--- a/tests/golden/node-disruption-policies/openshift4-nodes/apps/openshift4-nodes.yaml
+++ b/tests/golden/node-disruption-policies/openshift4-nodes/apps/openshift4-nodes.yaml
@@ -1,0 +1,5 @@
+spec:
+  ignoreDifferences: []
+  syncPolicy:
+    syncOptions:
+      - RespectIgnoreDifferences=true

--- a/tests/golden/node-disruption-policies/openshift4-nodes/openshift4-nodes/01_aggregated_clusterroles.yaml
+++ b/tests/golden/node-disruption-policies/openshift4-nodes/openshift4-nodes/01_aggregated_clusterroles.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: syn-openshift4-nodes-cluster-reader
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: 'true'
+  name: syn-openshift4-nodes-cluster-reader
+rules:
+  - apiGroups:
+      - machineconfiguration.openshift.io
+    resources:
+      - machineconfigs
+    verbs:
+      - get
+      - list
+      - watch

--- a/tests/golden/node-disruption-policies/openshift4-nodes/openshift4-nodes/10_kubeletconfigs.yaml
+++ b/tests/golden/node-disruption-policies/openshift4-nodes/openshift4-nodes/10_kubeletconfigs.yaml
@@ -1,0 +1,17 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: openshift4-nodes
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: openshift4-nodes
+    name: workers
+  name: workers
+spec:
+  kubeletConfig:
+    maxPods: 110
+  machineConfigPoolSelector:
+    matchExpressions:
+      - key: pools.operator.machineconfiguration.openshift.io/worker
+        operator: Exists

--- a/tests/golden/node-disruption-policies/openshift4-nodes/openshift4-nodes/10_nodeconfig.yaml
+++ b/tests/golden/node-disruption-policies/openshift4-nodes/openshift4-nodes/10_nodeconfig.yaml
@@ -1,0 +1,12 @@
+apiVersion: config.openshift.io/v1
+kind: Node
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: openshift4-nodes
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: openshift4-nodes
+    name: cluster
+  name: cluster
+spec:
+  cgroupMode: v1

--- a/tests/golden/node-disruption-policies/openshift4-nodes/openshift4-nodes/debug.yaml
+++ b/tests/golden/node-disruption-policies/openshift4-nodes/openshift4-nodes/debug.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/node-selector: ''
+    scheduler.alpha.kubernetes.io/defaultTolerations: '[{"operator":"Exists"}]'
+  labels:
+    name: syn-debug-nodes
+  name: syn-debug-nodes

--- a/tests/golden/node-disruption-policies/openshift4-nodes/openshift4-nodes/machineconfig_pruning.yaml
+++ b/tests/golden/node-disruption-policies/openshift4-nodes/openshift4-nodes/machineconfig_pruning.yaml
@@ -1,0 +1,134 @@
+apiVersion: v1
+data:
+  machineconfig_pruning.sh: |
+    #!/bin/bash
+    set -ex
+
+    for pool in $(kubectl get machineconfigpool -ojson | jq -r '.items[].metadata.name'); do
+      oc adm prune renderedmachineconfigs list --pool-name="$pool" |\
+        grep 'in use: false' |\
+        # keep 5 newest mc
+        head -n-5 |\
+        cut -d' ' -f1 |\
+        while read -r mc; do
+          kubectl delete machineconfig "$mc"
+        done
+    done
+kind: ConfigMap
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-prune-machineconfigs
+  name: appuio-prune-machineconfigs
+  namespace: openshift-machine-config-operator
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-prune-machineconfigs
+  name: appuio-prune-machineconfigs
+  namespace: openshift-machine-config-operator
+spec:
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      completions: 1
+      parallelism: 1
+      template:
+        metadata:
+          labels:
+            name: appuio-prune-machineconfigs
+        spec:
+          containers:
+            - args: []
+              command:
+                - /scripts/machineconfig_pruning.sh
+              env:
+                - name: HOME
+                  value: /export
+              image: quay.io/appuio/oc:v4.16
+              imagePullPolicy: IfNotPresent
+              name: prune-machineconfigs
+              ports: []
+              stdin: false
+              tty: false
+              volumeMounts:
+                - mountPath: /export
+                  name: export
+                - mountPath: /scripts
+                  name: scripts
+              workingDir: /export
+          imagePullSecrets: []
+          initContainers: []
+          restartPolicy: OnFailure
+          serviceAccountName: appuio-machineconfig-pruner
+          terminationGracePeriodSeconds: 30
+          volumes:
+            - emptyDir: {}
+              name: export
+            - configMap:
+                defaultMode: 360
+                name: appuio-prune-machineconfigs
+              name: scripts
+  schedule: 0 11 * * 3
+  successfulJobsHistoryLimit: 10
+  timeZone: Europe/Zurich
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-machineconfig-pruner
+  name: appuio:machineconfig-pruner
+rules:
+  - apiGroups:
+      - machineconfiguration.openshift.io
+    resources:
+      - machineconfigs
+    verbs:
+      - get
+      - list
+      - delete
+  - apiGroups:
+      - machineconfiguration.openshift.io
+    resources:
+      - machineconfigpools
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - ''
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-machineconfig-pruner
+  name: appuio:machineconfig-pruner
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: appuio:machineconfig-pruner
+subjects:
+  - kind: ServiceAccount
+    name: appuio-machineconfig-pruner
+    namespace: openshift-machine-config-operator
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-machineconfig-pruner
+  name: appuio-machineconfig-pruner
+  namespace: openshift-machine-config-operator

--- a/tests/golden/node-disruption-policies/openshift4-nodes/openshift4-nodes/machineconfigpool-app.yaml
+++ b/tests/golden/node-disruption-policies/openshift4-nodes/openshift4-nodes/machineconfigpool-app.yaml
@@ -1,0 +1,23 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: openshift4-nodes
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: openshift4-nodes
+    name: x-app
+    pools.operator.machineconfiguration.openshift.io/app: ''
+  name: x-app
+spec:
+  machineConfigSelector:
+    matchExpressions:
+      - key: machineconfiguration.openshift.io/role
+        operator: In
+        values:
+          - worker
+          - x-app
+          - app
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/app: ''

--- a/tests/golden/node-disruption-policies/openshift4-nodes/openshift4-nodes/machineconfigpool-infra.yaml
+++ b/tests/golden/node-disruption-policies/openshift4-nodes/openshift4-nodes/machineconfigpool-infra.yaml
@@ -1,0 +1,23 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: openshift4-nodes
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: openshift4-nodes
+    name: x-infra
+    pools.operator.machineconfiguration.openshift.io/infra: ''
+  name: x-infra
+spec:
+  machineConfigSelector:
+    matchExpressions:
+      - key: machineconfiguration.openshift.io/role
+        operator: In
+        values:
+          - worker
+          - x-infra
+          - infra
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/infra: ''

--- a/tests/golden/node-disruption-policies/openshift4-nodes/openshift4-nodes/machineconfigpool-storage.yaml
+++ b/tests/golden/node-disruption-policies/openshift4-nodes/openshift4-nodes/machineconfigpool-storage.yaml
@@ -1,0 +1,23 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: openshift4-nodes
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: openshift4-nodes
+    name: x-storage
+    pools.operator.machineconfiguration.openshift.io/storage: ''
+  name: x-storage
+spec:
+  machineConfigSelector:
+    matchExpressions:
+      - key: machineconfiguration.openshift.io/role
+        operator: In
+        values:
+          - worker
+          - x-storage
+          - storage
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/storage: ''

--- a/tests/golden/node-disruption-policies/openshift4-nodes/openshift4-nodes/nodedisruptionpolicies_managedresource.yaml
+++ b/tests/golden/node-disruption-policies/openshift4-nodes/openshift4-nodes/nodedisruptionpolicies_managedresource.yaml
@@ -10,7 +10,25 @@ spec:
     config.json: |-
       {
           "files": [
-
+              {
+                  "actions": [
+                      {
+                          "restart": {
+                              "serviceName": "chronyd.service"
+                          },
+                          "type": "Restart"
+                      }
+                  ],
+                  "path": "/etc/chrony.conf"
+              },
+              {
+                  "actions": [
+                      {
+                          "type": "None"
+                      }
+                  ],
+                  "path": "/usr/local/bin"
+              }
           ],
           "sshkey_actions": [
 

--- a/tests/golden/node-disruption-policies/openshift4-nodes/openshift4-nodes/nodedisruptionpolicies_managedresource.yaml
+++ b/tests/golden/node-disruption-policies/openshift4-nodes/openshift4-nodes/nodedisruptionpolicies_managedresource.yaml
@@ -178,13 +178,8 @@ spec:
     [ res ]
   triggers:
     - name: machineconfig
-      watchResource:
-        apiVersion: machineconfiguration.openshift.io/v1
-        kind: MachineConfig
-        labelSelector:
-          matchExpressions:
-            - key: machineconfiguration.openshift.io/role
-              operator: Exists
+      watchContextResource:
+        name: machineconfigs
     - name: machineconfiguration/cluster
       watchResource:
         apiVersion: operator.openshift.io/v1

--- a/tests/golden/node-disruption-policies/openshift4-nodes/openshift4-nodes/nodedisruptionpolicies_managedresource.yaml
+++ b/tests/golden/node-disruption-policies/openshift4-nodes/openshift4-nodes/nodedisruptionpolicies_managedresource.yaml
@@ -1,0 +1,197 @@
+apiVersion: espejote.io/v1alpha1
+kind: JsonnetLibrary
+metadata:
+  labels:
+    app.kubernetes.io/name: nodedisruptionpolicies
+  name: nodedisruptionpolicies
+  namespace: openshift-machine-config-operator
+spec:
+  data:
+    config.json: |-
+      {
+          "files": [
+
+          ],
+          "sshkey_actions": [
+
+          ],
+          "units": [
+
+          ]
+      }
+    ndp.libsonnet: |
+      // get node disruption policy from machineconfig annotation
+      local get_disruption_config(mc) =
+        local annotation_key = 'openshift4-nodes.syn.tools/node-disruption-policies';
+        local annotations = std.get(mc.metadata, 'annotations', {});
+        std.parseJson(std.get(annotations, annotation_key, '{}'));
+
+      // Validate passed list of node disruption policy actions.
+      // Currently only validates that actions lists with > 1 entry don't contain
+      // `Reboot` or `None`.
+      local validate_actions(actions) =
+        local valid =
+          std.length(actions) <= 1 ||
+          !(std.member(actions, { type: 'Reboot' }) || std.member(actions, { type: 'None' }));
+        assert valid : 'Actions %s is invalid' % [ actions ];
+        actions;
+
+      // Selects "most disruptive" list of actions from the passed list of lists.
+      // Reboot is treated as most disruptive, arbitrary other actions are
+      // concatenated (TBD if this makes sense) and None is treated as least
+      // disruptive.
+      local select_actions(actions) = validate_actions(std.foldl(
+        function(curr, a)
+          if std.length(a) == 0 then curr
+          else if std.length(curr) == 0 then a
+          else if curr[0].type == 'Reboot' then curr
+          else if a[0].type == 'Reboot' then a
+          else if curr[0].type == 'None' then a
+          else if a[0].type == 'None' then curr
+          else curr + a,
+        actions,
+        []
+      ));
+
+      // Removes duplicate entries from a list of policies. Should only be used for
+      // `files` and `units` policy lists. For duplicate entries, the most
+      // disruptive action (cf. `select_actions()` is picked for the resulting
+      // entry.
+      local remove_duplicates(pols, keyField) =
+        local pol_actions = std.foldl(function(res, p) res { [p[keyField]]+: [ p.actions ] }, pols, {});
+        [
+          {
+            [keyField]: k,
+            actions: select_actions(pol_actions[k]),
+          }
+          for k in std.objectFields(pol_actions)
+        ];
+
+
+      {
+        get_disruption_config: get_disruption_config,
+        select_actions: select_actions,
+        remove_duplicates: remove_duplicates,
+      }
+---
+apiVersion: espejote.io/v1alpha1
+kind: ManagedResource
+metadata:
+  annotations:
+    syn.tools/description: |
+      Manages `spec.nodeDisruptionPolicies` in the `machineconfiguration.operator/cluster` resource.
+
+      The contents of `spec.nodeDisruptionPolicies` are constructed from the
+      annotation `openshift4-nodes.syn.tools/node-disruption-policies` on all
+      non-generated MachineConfigs. We generally recommend defining very
+      specific paths for `files` disruption policies in order to avoid
+      confilicting configurations in the resulting merged config.
+
+      Any unmanaged contents of `spec.nodeDisruptionPolicies` are overwritten.
+      We explicitly execute the template when the
+      `machineconfiguration.operator/cluster` resource changes.
+
+      Generic disruption policies which are provided via Project Syn
+      parameter are provided in field `config.json` in the
+      `nodedisruptionpolicies` Espejote JsonnetLibrary resource.
+
+      NOTE: Don't configure `type: Restart` for systemd units that are managed
+      in the machineconfig resource. Doing so will cause nodes to become
+      degraded if the machineconfig is deleted.
+
+      NOTE: In general, we can't guarantee that node disruption policies
+      provided in an annotation will still be active when the machineconfig
+      is deleted. If you want to guarantee that removing a machineconfig
+      doesn't unnecessesarily reboots machines, we recommend defining
+      appropriate node disruption policies via the Project Syn hierarchy.
+  labels:
+    app.kubernetes.io/name: nodedisruptionpolicies
+  name: nodedisruptionpolicies
+  namespace: openshift-machine-config-operator
+spec:
+  applyOptions:
+    force: true
+  context:
+    - name: machineconfigs
+      resource:
+        apiVersion: machineconfiguration.openshift.io/v1
+        kind: MachineConfig
+        labelSelector:
+          matchExpressions:
+            - key: machineconfiguration.openshift.io/role
+              operator: Exists
+  serviceAccountRef:
+    name: nodedisruptionpolicies-manager
+  template: |
+    local esp = import 'espejote.libsonnet';
+    local ndp = import 'nodedisruptionpolicies/ndp.libsonnet';
+
+    local config = import 'nodedisruptionpolicies/config.json';
+    local machineconfigs = esp.context().machineconfigs;
+
+    local render_nodedisruptionpolicies() =
+      local configs = [ ndp.get_disruption_config(mc) for mc in machineconfigs ];
+      local policies =
+        {
+          files+:
+            std.get(config, 'files', []) +
+            std.flattenArrays([ std.get(dc, 'files', []) for dc in configs ]),
+          units+:
+            std.get(config, 'units', []) +
+            std.flattenArrays([ std.get(dc, 'units', []) for dc in configs ]),
+          sshkey+: {
+            actions:
+              [ std.get(config, 'sshkey_actions', []) ] +
+              [ std.get(dc, 'sshkey', { actions: [] }).actions for dc in configs ],
+          },
+        };
+      {
+        files: ndp.remove_duplicates(
+          std.sort(policies.files, keyF=function(e) e.path),
+          'path'
+        ),
+        units: ndp.remove_duplicates(
+          std.sort(policies.units, keyF=function(e) e.name),
+          'name'
+        ),
+        sshkey: { actions: ndp.select_actions(policies.sshkey.actions) },
+      };
+
+    local res = {
+      apiVersion: 'operator.openshift.io/v1',
+      kind: 'MachineConfiguration',
+      metadata: {
+        name: 'cluster',
+      },
+      spec: {
+        nodeDisruptionPolicy: render_nodedisruptionpolicies(),
+      },
+    };
+
+    assert
+      std.length(res.spec.nodeDisruptionPolicy.files) <= 50 :
+      'Max supported length of nodeDisruptionPolicy.files is 50';
+    assert
+      std.length(res.spec.nodeDisruptionPolicy.units) <= 50 :
+      'Max supported length of nodeDisruptionPolicy.units is 50';
+
+    [ res ]
+  triggers:
+    - name: machineconfig
+      watchResource:
+        apiVersion: machineconfiguration.openshift.io/v1
+        kind: MachineConfig
+        labelSelector:
+          matchExpressions:
+            - key: machineconfiguration.openshift.io/role
+              operator: Exists
+    - name: machineconfiguration/cluster
+      watchResource:
+        apiVersion: operator.openshift.io/v1
+        kind: MachineConfiguration
+    - name: jsonnetlib
+      watchResource:
+        apiVersion: espejote.io/v1alpha1
+        kind: JsonnetLibrary
+        name: nodedisruptionpolicies
+        namespace: openshift-machine-config-operator

--- a/tests/golden/node-disruption-policies/openshift4-nodes/openshift4-nodes/nodedisruptionpolicies_rbac.yaml
+++ b/tests/golden/node-disruption-policies/openshift4-nodes/openshift4-nodes/nodedisruptionpolicies_rbac.yaml
@@ -1,0 +1,86 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  labels:
+    name: nodedisruptionpolicies-manager
+  name: nodedisruptionpolicies-manager
+  namespace: openshift-machine-config-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: espejote-nodedisruptionpolicies
+  name: espejote:nodedisruptionpolicies
+rules:
+  - apiGroups:
+      - operator.openshift.io
+    resources:
+      - machineconfigurations
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+  - apiGroups:
+      - machineconfiguration.openshift.io
+    resources:
+      - machineconfigs
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: {}
+  labels:
+    name: espejote-nodedisruptionpolicies
+  name: espejote:nodedisruptionpolicies
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: espejote:nodedisruptionpolicies
+subjects:
+  - kind: ServiceAccount
+    name: nodedisruptionpolicies-manager
+    namespace: openshift-machine-config-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations: {}
+  labels:
+    name: espejote-nodedisruptionpolicies
+  name: espejote:nodedisruptionpolicies
+  namespace: openshift-machine-config-operator
+rules:
+  - apiGroups:
+      - espejote.io
+    resources:
+      - jsonnetlibraries
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations: {}
+  labels:
+    name: espejote-nodedisruptionpolicies
+  name: espejote:nodedisruptionpolicies
+  namespace: openshift-machine-config-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: espejote:nodedisruptionpolicies
+subjects:
+  - kind: ServiceAccount
+    name: nodedisruptionpolicies-manager
+    namespace: openshift-machine-config-operator

--- a/tests/node-disruption-policies.yml
+++ b/tests/node-disruption-policies.yml
@@ -1,0 +1,13 @@
+applications:
+  - espejote
+
+parameters:
+  kapitan:
+    dependencies:
+      - type: https
+        source: https://raw.githubusercontent.com/projectsyn/component-espejote/v0.2.0/lib/espejote.libsonnet
+        output_path: vendor/lib/espejote.libsonnet
+
+  openshift4_nodes:
+    openshiftVersion:
+      Minor: '17'

--- a/tests/node-disruption-policies.yml
+++ b/tests/node-disruption-policies.yml
@@ -11,3 +11,13 @@ parameters:
   openshift4_nodes:
     openshiftVersion:
       Minor: '17'
+    nodeDisruptionPolicies:
+      files:
+        '/usr/local/bin':
+          actions:
+            - type: None
+        '/etc/chrony.conf':
+          actions:
+            - type: Restart
+              restart:
+                serviceName: chronyd.service


### PR DESCRIPTION
Node disruption policy entries can be provided via component parameter `nodeDisruptionPolicies` or by adding annotation
`openshift4-nodes.syn.tools/node-disruption-policies` with string-encoded JSON contents.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
