### PR TITLE
Allow defaulting annotations for LB services

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -7,7 +7,7 @@
       "name": "OpenShift 4 Nodes",
       "slug": "openshift4-nodes",
       "parameter_key": "openshift4_nodes",
-      "test_cases": "defaults gcp maxpods pidslimit machineconfig remove-machineconfigpool autoscaling capacity node-disruption-policies",
+      "test_cases": "defaults gcp maxpods pidslimit machineconfig remove-machineconfigpool autoscaling capacity node-disruption-policies lb-default-annotation",
       "add_lib": "n",
       "add_pp": "n",
       "add_golden": "y",

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,6 +41,7 @@ jobs:
           - autoscaling
           - capacity
           - node-disruption-policies
+          - lb-default-annotation
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}
@@ -64,6 +65,7 @@ jobs:
           - autoscaling
           - capacity
           - node-disruption-policies
+          - lb-default-annotation
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}

--- a/Makefile.vars.mk
+++ b/Makefile.vars.mk
@@ -57,4 +57,4 @@ KUBENT_IMAGE    ?= ghcr.io/doitintl/kube-no-trouble:latest
 KUBENT_DOCKER   ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) --entrypoint=/app/kubent $(KUBENT_IMAGE)
 
 instance ?= defaults
-test_instances = tests/defaults.yml tests/gcp.yml tests/maxpods.yml tests/pidslimit.yml tests/machineconfig.yml tests/remove-machineconfigpool.yml tests/autoscaling.yml tests/capacity.yml tests/node-disruption-policies.yml
+test_instances = tests/defaults.yml tests/gcp.yml tests/maxpods.yml tests/pidslimit.yml tests/machineconfig.yml tests/remove-machineconfigpool.yml tests/autoscaling.yml tests/capacity.yml tests/node-disruption-policies.yml tests/lb-default-annotation.yml

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -91,6 +91,8 @@ parameters:
 
     machineSets: {}
 
+    serviceLoadBalancerDefaultAnnotations: {}
+
     autoscaling:
       enabled: false
       addAutoscalerArgs:

--- a/class/openshift4-nodes.yml
+++ b/class/openshift4-nodes.yml
@@ -19,5 +19,6 @@ parameters:
           - openshift4-nodes/component/prune-machine-configs.jsonnet
           - openshift4-nodes/component/capacity.jsonnet
           - openshift4-nodes/component/node-disruption-policies.jsonnet
+          - openshift4-nodes/component/service-loadbalancer-default-annotations.jsonnet
         input_type: jsonnet
         output_path: openshift4-nodes/

--- a/component/espejote-templates/service-loadbalancer-default-annotations.jsonnet
+++ b/component/espejote-templates/service-loadbalancer-default-annotations.jsonnet
@@ -1,0 +1,30 @@
+local esp = import 'espejote.libsonnet';
+local defaultAnnotations = import 'service-loadbalancer-default-annotations/annotations.json';
+
+local lbServices = std.filter(
+  function(s) std.get(s.spec, 'type') == 'LoadBalancer',
+  esp.context().services
+);
+
+local defaultedAnnotationsForService = function(s) {
+  [if !std.objectHas(std.get(s.metadata, 'annotations', {}), k) then k]: defaultAnnotations[k]
+  for k in std.objectFields(defaultAnnotations)
+};
+
+local annotationPatchForService = function(s) {
+  apiVersion: s.apiVersion,
+  kind: s.kind,
+  metadata: {
+    name: s.metadata.name,
+    namespace: s.metadata.namespace,
+    annotations: defaultedAnnotationsForService(s),
+  },
+};
+
+std.filter(
+  function(p) p.metadata.annotations != {},
+  std.map(
+    annotationPatchForService,
+    lbServices,
+  ),
+)

--- a/component/service-loadbalancer-default-annotations.jsonnet
+++ b/component/service-loadbalancer-default-annotations.jsonnet
@@ -1,0 +1,82 @@
+local esp = import 'lib/espejote.libsonnet';
+local kap = import 'lib/kapitan.libjsonnet';
+local kube = import 'lib/kube.libjsonnet';
+
+local inv = kap.inventory();
+local params = inv.parameters.openshift4_nodes;
+
+local namespace = kube.Namespace('appuio-openshift4-nodes');
+
+local sa = kube.ServiceAccount('service-loadbalancer-default-annotations-manager') {
+  metadata+: {
+    namespace: namespace.metadata.name,
+  },
+};
+
+local cr = kube.ClusterRole('espejote:service-loadbalancer-default-annotations') {
+  rules: [
+    {
+      apiGroups: [ '' ],
+      resources: [ 'services' ],
+      verbs: [ 'get', 'list', 'watch', 'update', 'patch' ],
+    },
+  ],
+};
+
+local crb = kube.ClusterRoleBinding('espejote:service-loadbalancer-default-annotations') {
+  roleRef_: cr,
+  subjects_: [ sa ],
+};
+
+local jsonnetlib = esp.jsonnetLibrary('service-loadbalancer-default-annotations', namespace.metadata.name) {
+  spec: {
+    data: {
+      'annotations.json': std.manifestJson(params.serviceLoadBalancerDefaultAnnotations),
+    },
+  },
+};
+
+local managedresource =
+  assert std.member(inv.applications, 'espejote') : 'The serviceLoadBalancerDefaultAnnotations patch depends on espejote';
+  esp.managedResource('service-loadbalancer-default-annotations', namespace.metadata.name) {
+    metadata+: {
+      annotations: {
+        'syn.tools/description': |||
+          This ManagedResource adds default annotations to all services with `spec.type: LoadBalancer`.
+          Annotations are taken from a JsonnetLibrary with the same name.
+          The JsonnetLibrary contains a file `annotations.json` with the annotations to be added.
+          If an annotation is already set on the service, it will not be overridden.
+        |||,
+      },
+    },
+    spec: {
+      serviceAccountRef: { name: sa.metadata.name },
+      context: [
+        {
+          name: 'services',
+          resource: {
+            apiVersion: 'v1',
+            kind: 'Service',
+            namespace: '',
+          },
+        },
+      ],
+      triggers: [
+        {
+          name: 'service',
+          watchContextResource: {
+            name: 'services',
+          },
+        },
+      ],
+      template: importstr 'espejote-templates/service-loadbalancer-default-annotations.jsonnet',
+    },
+  };
+
+if std.length(params.serviceLoadBalancerDefaultAnnotations) > 0 then
+  {
+    'service-loadbalancer-default-annotations_rbac': [ namespace, sa, cr, crb ],
+    'service-loadbalancer-default-annotations_managedresource': [ jsonnetlib, managedresource ],
+  }
+else
+  {}

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -210,6 +210,23 @@ This gives you the full control over the resulting `MachineSet` or `ControlPlane
 Values given here will be merged with precedence with the defaults configured in <<defaultSpec>>.
 The values can be everything that's accepted in the `spec` field of a `machinesets.machine.openshift.io` object.
 
+== `serviceLoadBalancerDefaultAnnotations`
+
+[horizontal]
+type:: dictionary
+default:: `{}`
+example::
++
+[source,yaml]
+----
+serviceLoadBalancerDefaultAnnotations:
+  service.beta.kubernetes.io/exoscale-loadbalancer-service-instancepool-id: 7026DCCB-39B4-451B-AB38-EB527CC836A4
+----
+
+Creates an espejote ManagedResource adding default annotations to Services with `spe.type: LoadBalancer`.
+
+Can be used to inject annotations required for some LoadBalancer implementations.
+
 == `machineSets`
 
 [horizontal]

--- a/tests/golden/lb-default-annotation/openshift4-nodes/apps/openshift4-nodes.yaml
+++ b/tests/golden/lb-default-annotation/openshift4-nodes/apps/openshift4-nodes.yaml
@@ -1,0 +1,5 @@
+spec:
+  ignoreDifferences: []
+  syncPolicy:
+    syncOptions:
+      - RespectIgnoreDifferences=true

--- a/tests/golden/lb-default-annotation/openshift4-nodes/openshift4-nodes/01_aggregated_clusterroles.yaml
+++ b/tests/golden/lb-default-annotation/openshift4-nodes/openshift4-nodes/01_aggregated_clusterroles.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: syn-openshift4-nodes-cluster-reader
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: 'true'
+  name: syn-openshift4-nodes-cluster-reader
+rules:
+  - apiGroups:
+      - machineconfiguration.openshift.io
+    resources:
+      - machineconfigs
+    verbs:
+      - get
+      - list
+      - watch

--- a/tests/golden/lb-default-annotation/openshift4-nodes/openshift4-nodes/10_kubeletconfigs.yaml
+++ b/tests/golden/lb-default-annotation/openshift4-nodes/openshift4-nodes/10_kubeletconfigs.yaml
@@ -1,0 +1,17 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: openshift4-nodes
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: openshift4-nodes
+    name: workers
+  name: workers
+spec:
+  kubeletConfig:
+    maxPods: 110
+  machineConfigPoolSelector:
+    matchExpressions:
+      - key: pools.operator.machineconfiguration.openshift.io/worker
+        operator: Exists

--- a/tests/golden/lb-default-annotation/openshift4-nodes/openshift4-nodes/10_nodeconfig.yaml
+++ b/tests/golden/lb-default-annotation/openshift4-nodes/openshift4-nodes/10_nodeconfig.yaml
@@ -1,0 +1,12 @@
+apiVersion: config.openshift.io/v1
+kind: Node
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: openshift4-nodes
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: openshift4-nodes
+    name: cluster
+  name: cluster
+spec:
+  cgroupMode: v1

--- a/tests/golden/lb-default-annotation/openshift4-nodes/openshift4-nodes/debug.yaml
+++ b/tests/golden/lb-default-annotation/openshift4-nodes/openshift4-nodes/debug.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/node-selector: ''
+    scheduler.alpha.kubernetes.io/defaultTolerations: '[{"operator":"Exists"}]'
+  labels:
+    name: syn-debug-nodes
+  name: syn-debug-nodes

--- a/tests/golden/lb-default-annotation/openshift4-nodes/openshift4-nodes/machineconfig_pruning.yaml
+++ b/tests/golden/lb-default-annotation/openshift4-nodes/openshift4-nodes/machineconfig_pruning.yaml
@@ -1,0 +1,134 @@
+apiVersion: v1
+data:
+  machineconfig_pruning.sh: |
+    #!/bin/bash
+    set -ex
+
+    for pool in $(kubectl get machineconfigpool -ojson | jq -r '.items[].metadata.name'); do
+      oc adm prune renderedmachineconfigs list --pool-name="$pool" |\
+        grep 'in use: false' |\
+        # keep 5 newest mc
+        head -n-5 |\
+        cut -d' ' -f1 |\
+        while read -r mc; do
+          kubectl delete machineconfig "$mc"
+        done
+    done
+kind: ConfigMap
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-prune-machineconfigs
+  name: appuio-prune-machineconfigs
+  namespace: openshift-machine-config-operator
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-prune-machineconfigs
+  name: appuio-prune-machineconfigs
+  namespace: openshift-machine-config-operator
+spec:
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      completions: 1
+      parallelism: 1
+      template:
+        metadata:
+          labels:
+            name: appuio-prune-machineconfigs
+        spec:
+          containers:
+            - args: []
+              command:
+                - /scripts/machineconfig_pruning.sh
+              env:
+                - name: HOME
+                  value: /export
+              image: quay.io/appuio/oc:v4.16
+              imagePullPolicy: IfNotPresent
+              name: prune-machineconfigs
+              ports: []
+              stdin: false
+              tty: false
+              volumeMounts:
+                - mountPath: /export
+                  name: export
+                - mountPath: /scripts
+                  name: scripts
+              workingDir: /export
+          imagePullSecrets: []
+          initContainers: []
+          restartPolicy: OnFailure
+          serviceAccountName: appuio-machineconfig-pruner
+          terminationGracePeriodSeconds: 30
+          volumes:
+            - emptyDir: {}
+              name: export
+            - configMap:
+                defaultMode: 360
+                name: appuio-prune-machineconfigs
+              name: scripts
+  schedule: 0 11 * * 3
+  successfulJobsHistoryLimit: 10
+  timeZone: Europe/Zurich
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-machineconfig-pruner
+  name: appuio:machineconfig-pruner
+rules:
+  - apiGroups:
+      - machineconfiguration.openshift.io
+    resources:
+      - machineconfigs
+    verbs:
+      - get
+      - list
+      - delete
+  - apiGroups:
+      - machineconfiguration.openshift.io
+    resources:
+      - machineconfigpools
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - ''
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-machineconfig-pruner
+  name: appuio:machineconfig-pruner
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: appuio:machineconfig-pruner
+subjects:
+  - kind: ServiceAccount
+    name: appuio-machineconfig-pruner
+    namespace: openshift-machine-config-operator
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-machineconfig-pruner
+  name: appuio-machineconfig-pruner
+  namespace: openshift-machine-config-operator

--- a/tests/golden/lb-default-annotation/openshift4-nodes/openshift4-nodes/machineconfigpool-app.yaml
+++ b/tests/golden/lb-default-annotation/openshift4-nodes/openshift4-nodes/machineconfigpool-app.yaml
@@ -1,0 +1,23 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: openshift4-nodes
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: openshift4-nodes
+    name: x-app
+    pools.operator.machineconfiguration.openshift.io/app: ''
+  name: x-app
+spec:
+  machineConfigSelector:
+    matchExpressions:
+      - key: machineconfiguration.openshift.io/role
+        operator: In
+        values:
+          - worker
+          - x-app
+          - app
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/app: ''

--- a/tests/golden/lb-default-annotation/openshift4-nodes/openshift4-nodes/machineconfigpool-infra.yaml
+++ b/tests/golden/lb-default-annotation/openshift4-nodes/openshift4-nodes/machineconfigpool-infra.yaml
@@ -1,0 +1,23 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: openshift4-nodes
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: openshift4-nodes
+    name: x-infra
+    pools.operator.machineconfiguration.openshift.io/infra: ''
+  name: x-infra
+spec:
+  machineConfigSelector:
+    matchExpressions:
+      - key: machineconfiguration.openshift.io/role
+        operator: In
+        values:
+          - worker
+          - x-infra
+          - infra
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/infra: ''

--- a/tests/golden/lb-default-annotation/openshift4-nodes/openshift4-nodes/machineconfigpool-storage.yaml
+++ b/tests/golden/lb-default-annotation/openshift4-nodes/openshift4-nodes/machineconfigpool-storage.yaml
@@ -1,0 +1,23 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: openshift4-nodes
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: openshift4-nodes
+    name: x-storage
+    pools.operator.machineconfiguration.openshift.io/storage: ''
+  name: x-storage
+spec:
+  machineConfigSelector:
+    matchExpressions:
+      - key: machineconfiguration.openshift.io/role
+        operator: In
+        values:
+          - worker
+          - x-storage
+          - storage
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/storage: ''

--- a/tests/golden/lb-default-annotation/openshift4-nodes/openshift4-nodes/service-loadbalancer-default-annotations_managedresource.yaml
+++ b/tests/golden/lb-default-annotation/openshift4-nodes/openshift4-nodes/service-loadbalancer-default-annotations_managedresource.yaml
@@ -1,0 +1,71 @@
+apiVersion: espejote.io/v1alpha1
+kind: JsonnetLibrary
+metadata:
+  labels:
+    app.kubernetes.io/name: service-loadbalancer-default-annotations
+  name: service-loadbalancer-default-annotations
+  namespace: appuio-openshift4-nodes
+spec:
+  data:
+    annotations.json: |-
+      {
+          "service.beta.kubernetes.io/exoscale-loadbalancer-service-instancepool-id": "7026DCCB-39B4-451B-AB38-EB527CC836A4"
+      }
+---
+apiVersion: espejote.io/v1alpha1
+kind: ManagedResource
+metadata:
+  annotations:
+    syn.tools/description: |
+      This ManagedResource adds default annotations to all services with `spec.type: LoadBalancer`.
+      Annotations are taken from a JsonnetLibrary with the same name.
+      The JsonnetLibrary contains a file `annotations.json` with the annotations to be added.
+      If an annotation is already set on the service, it will not be overridden.
+  labels:
+    app.kubernetes.io/name: service-loadbalancer-default-annotations
+  name: service-loadbalancer-default-annotations
+  namespace: appuio-openshift4-nodes
+spec:
+  context:
+    - name: services
+      resource:
+        apiVersion: v1
+        kind: Service
+        namespace: ''
+  serviceAccountRef:
+    name: service-loadbalancer-default-annotations-manager
+  template: |
+    local esp = import 'espejote.libsonnet';
+    local defaultAnnotations = import 'service-loadbalancer-default-annotations/annotations.json';
+
+    local lbServices = std.filter(
+      function(s) std.get(s.spec, 'type') == 'LoadBalancer',
+      esp.context().services
+    );
+
+    local defaultedAnnotationsForService = function(s) {
+      [if !std.objectHas(std.get(s.metadata, 'annotations', {}), k) then k]: defaultAnnotations[k]
+      for k in std.objectFields(defaultAnnotations)
+    };
+
+    local annotationPatchForService = function(s) {
+      apiVersion: s.apiVersion,
+      kind: s.kind,
+      metadata: {
+        name: s.metadata.name,
+        namespace: s.metadata.namespace,
+        annotations: defaultedAnnotationsForService(s),
+      },
+    };
+
+    std.filter(
+      function(p) p.metadata.annotations != {},
+      std.map(
+        annotationPatchForService,
+        lbServices,
+      ),
+    )
+  triggers:
+    - name: service
+      watchContextResource:
+        name: services

--- a/tests/golden/lb-default-annotation/openshift4-nodes/openshift4-nodes/service-loadbalancer-default-annotations_rbac.yaml
+++ b/tests/golden/lb-default-annotation/openshift4-nodes/openshift4-nodes/service-loadbalancer-default-annotations_rbac.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-openshift4-nodes
+  name: appuio-openshift4-nodes
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  labels:
+    name: service-loadbalancer-default-annotations-manager
+  name: service-loadbalancer-default-annotations-manager
+  namespace: appuio-openshift4-nodes
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: espejote-service-loadbalancer-default-annotations
+  name: espejote:service-loadbalancer-default-annotations
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: {}
+  labels:
+    name: espejote-service-loadbalancer-default-annotations
+  name: espejote:service-loadbalancer-default-annotations
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: espejote:service-loadbalancer-default-annotations
+subjects:
+  - kind: ServiceAccount
+    name: service-loadbalancer-default-annotations-manager
+    namespace: appuio-openshift4-nodes

--- a/tests/lb-default-annotation.yml
+++ b/tests/lb-default-annotation.yml
@@ -1,0 +1,3 @@
+# Overwrite parameters here
+
+# parameters: {...}

--- a/tests/lb-default-annotation.yml
+++ b/tests/lb-default-annotation.yml
@@ -1,3 +1,13 @@
-# Overwrite parameters here
+applications:
+  - espejote
 
-# parameters: {...}
+parameters:
+  kapitan:
+    dependencies:
+      - type: https
+        source: https://raw.githubusercontent.com/projectsyn/component-espejote/v0.2.0/lib/espejote.libsonnet
+        output_path: vendor/lib/espejote.libsonnet
+
+  openshift4_nodes:
+    serviceLoadBalancerDefaultAnnotations:
+      service.beta.kubernetes.io/exoscale-loadbalancer-service-instancepool-id: 7026DCCB-39B4-451B-AB38-EB527CC836A4


### PR DESCRIPTION
Used to inject `service.beta.kubernetes.io/exoscale-loadbalancer-service-instancepool-id` on Exoscale.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
