### PR TITLE
Add support for anti-affinity keys on Cloudscale clusters

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -7,7 +7,7 @@
       "name": "OpenShift 4 Nodes",
       "slug": "openshift4-nodes",
       "parameter_key": "openshift4_nodes",
-      "test_cases": "defaults gcp maxpods pidslimit machineconfig remove-machineconfigpool autoscaling capacity node-disruption-policies",
+      "test_cases": "defaults gcp maxpods pidslimit machineconfig remove-machineconfigpool autoscaling capacity node-disruption-policies cloudscale",
       "add_lib": "n",
       "add_pp": "n",
       "add_golden": "y",

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,6 +41,7 @@ jobs:
           - autoscaling
           - capacity
           - node-disruption-policies
+          - cloudscale
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}
@@ -64,6 +65,7 @@ jobs:
           - autoscaling
           - capacity
           - node-disruption-policies
+          - cloudscale
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}

--- a/Makefile.vars.mk
+++ b/Makefile.vars.mk
@@ -57,4 +57,4 @@ KUBENT_IMAGE    ?= ghcr.io/doitintl/kube-no-trouble:latest
 KUBENT_DOCKER   ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) --entrypoint=/app/kubent $(KUBENT_IMAGE)
 
 instance ?= defaults
-test_instances = tests/defaults.yml tests/gcp.yml tests/maxpods.yml tests/pidslimit.yml tests/machineconfig.yml tests/remove-machineconfigpool.yml tests/autoscaling.yml tests/capacity.yml tests/node-disruption-policies.yml
+test_instances = tests/defaults.yml tests/gcp.yml tests/maxpods.yml tests/pidslimit.yml tests/machineconfig.yml tests/remove-machineconfigpool.yml tests/autoscaling.yml tests/capacity.yml tests/node-disruption-policies.yml tests/cloudscale.yml

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -48,6 +48,7 @@ parameters:
                 tags: []
                 userDataSecret:
                   name: worker-user-data
+      cloudscale: {}
     controlPlaneDefaultSpecs:
       vsphere: {}
       aws: {}
@@ -84,6 +85,7 @@ parameters:
                         - https://www.googleapis.com/auth/cloud-platform
                   userDataSecret:
                     name: master-user-data
+      cloudscale: {}
     nodeConfig:
       cgroupMode: v1
 

--- a/tests/cloudscale.yml
+++ b/tests/cloudscale.yml
@@ -1,0 +1,3 @@
+# Overwrite parameters here
+
+# parameters: {...}

--- a/tests/cloudscale.yml
+++ b/tests/cloudscale.yml
@@ -1,3 +1,47 @@
-# Overwrite parameters here
+parameters:
+  openshift:
+    baseDomain: my.base.domain
+    cloudscale:
+      worker_flavor: plus-16-4
+      infra_flavor: plus-16-4
+      subnet_uuid: some_subnet_uuid_here
+      rhcos_image_slug: rhcos-4.17
+  facts:
+    cloud: cloudscale
+    region: lpg
+  openshift4_nodes:
+    defaultSpecs:
+      cloudscale:
+        template:
+          spec:
+            metadata:
+              labels:
+                syn.tools/cluster-id: ${cluster:name}
+            providerSpec:
+              value:
+                image: 'custom:${openshift:cloudscale:rhcos_image_slug}'
+                interfaces:
+                  - addresses:
+                      - subnetUUID: '${openshift:cloudscale:subnet_uuid}'
+                    type: Private
+                zone: '${facts:region}1'
+                baseDomain: ${openshift:baseDomain}
+                flavor: '${openshift:cloudscale:worker_flavor}'
+                rootVolumeSizeGB: 100
+                tokenSecret:
+                  name: cloudscale-rw-token
+                userDataSecret:
+                  name: cloudscale-user-data
 
-# parameters: {...}
+    projectName: cluster-test
+    infrastructureID: ${cluster:name}
+
+    nodeGroups:
+      worker:
+        role: app
+        replicas: 3
+      infra:
+        replicas: 4
+        providerSpec:
+          value:
+            test: foo

--- a/tests/golden/cloudscale/openshift4-nodes/apps/openshift4-nodes.yaml
+++ b/tests/golden/cloudscale/openshift4-nodes/apps/openshift4-nodes.yaml
@@ -1,0 +1,5 @@
+spec:
+  ignoreDifferences: []
+  syncPolicy:
+    syncOptions:
+      - RespectIgnoreDifferences=true

--- a/tests/golden/cloudscale/openshift4-nodes/openshift4-nodes/01_aggregated_clusterroles.yaml
+++ b/tests/golden/cloudscale/openshift4-nodes/openshift4-nodes/01_aggregated_clusterroles.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: syn-openshift4-nodes-cluster-reader
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: 'true'
+  name: syn-openshift4-nodes-cluster-reader
+rules:
+  - apiGroups:
+      - machineconfiguration.openshift.io
+    resources:
+      - machineconfigs
+    verbs:
+      - get
+      - list
+      - watch

--- a/tests/golden/cloudscale/openshift4-nodes/openshift4-nodes/10_kubeletconfigs.yaml
+++ b/tests/golden/cloudscale/openshift4-nodes/openshift4-nodes/10_kubeletconfigs.yaml
@@ -1,0 +1,17 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: openshift4-nodes
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: openshift4-nodes
+    name: workers
+  name: workers
+spec:
+  kubeletConfig:
+    maxPods: 110
+  machineConfigPoolSelector:
+    matchExpressions:
+      - key: pools.operator.machineconfiguration.openshift.io/worker
+        operator: Exists

--- a/tests/golden/cloudscale/openshift4-nodes/openshift4-nodes/10_nodeconfig.yaml
+++ b/tests/golden/cloudscale/openshift4-nodes/openshift4-nodes/10_nodeconfig.yaml
@@ -1,0 +1,12 @@
+apiVersion: config.openshift.io/v1
+kind: Node
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: openshift4-nodes
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: openshift4-nodes
+    name: cluster
+  name: cluster
+spec:
+  cgroupMode: v1

--- a/tests/golden/cloudscale/openshift4-nodes/openshift4-nodes/debug.yaml
+++ b/tests/golden/cloudscale/openshift4-nodes/openshift4-nodes/debug.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/node-selector: ''
+    scheduler.alpha.kubernetes.io/defaultTolerations: '[{"operator":"Exists"}]'
+  labels:
+    name: syn-debug-nodes
+  name: syn-debug-nodes

--- a/tests/golden/cloudscale/openshift4-nodes/openshift4-nodes/machineconfig_pruning.yaml
+++ b/tests/golden/cloudscale/openshift4-nodes/openshift4-nodes/machineconfig_pruning.yaml
@@ -1,0 +1,134 @@
+apiVersion: v1
+data:
+  machineconfig_pruning.sh: |
+    #!/bin/bash
+    set -ex
+
+    for pool in $(kubectl get machineconfigpool -ojson | jq -r '.items[].metadata.name'); do
+      oc adm prune renderedmachineconfigs list --pool-name="$pool" |\
+        grep 'in use: false' |\
+        # keep 5 newest mc
+        head -n-5 |\
+        cut -d' ' -f1 |\
+        while read -r mc; do
+          kubectl delete machineconfig "$mc"
+        done
+    done
+kind: ConfigMap
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-prune-machineconfigs
+  name: appuio-prune-machineconfigs
+  namespace: openshift-machine-config-operator
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-prune-machineconfigs
+  name: appuio-prune-machineconfigs
+  namespace: openshift-machine-config-operator
+spec:
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      completions: 1
+      parallelism: 1
+      template:
+        metadata:
+          labels:
+            name: appuio-prune-machineconfigs
+        spec:
+          containers:
+            - args: []
+              command:
+                - /scripts/machineconfig_pruning.sh
+              env:
+                - name: HOME
+                  value: /export
+              image: quay.io/appuio/oc:v4.16
+              imagePullPolicy: IfNotPresent
+              name: prune-machineconfigs
+              ports: []
+              stdin: false
+              tty: false
+              volumeMounts:
+                - mountPath: /export
+                  name: export
+                - mountPath: /scripts
+                  name: scripts
+              workingDir: /export
+          imagePullSecrets: []
+          initContainers: []
+          restartPolicy: OnFailure
+          serviceAccountName: appuio-machineconfig-pruner
+          terminationGracePeriodSeconds: 30
+          volumes:
+            - emptyDir: {}
+              name: export
+            - configMap:
+                defaultMode: 360
+                name: appuio-prune-machineconfigs
+              name: scripts
+  schedule: 0 11 * * 3
+  successfulJobsHistoryLimit: 10
+  timeZone: Europe/Zurich
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-machineconfig-pruner
+  name: appuio:machineconfig-pruner
+rules:
+  - apiGroups:
+      - machineconfiguration.openshift.io
+    resources:
+      - machineconfigs
+    verbs:
+      - get
+      - list
+      - delete
+  - apiGroups:
+      - machineconfiguration.openshift.io
+    resources:
+      - machineconfigpools
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - ''
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-machineconfig-pruner
+  name: appuio:machineconfig-pruner
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: appuio:machineconfig-pruner
+subjects:
+  - kind: ServiceAccount
+    name: appuio-machineconfig-pruner
+    namespace: openshift-machine-config-operator
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-machineconfig-pruner
+  name: appuio-machineconfig-pruner
+  namespace: openshift-machine-config-operator

--- a/tests/golden/cloudscale/openshift4-nodes/openshift4-nodes/machineconfigpool-app.yaml
+++ b/tests/golden/cloudscale/openshift4-nodes/openshift4-nodes/machineconfigpool-app.yaml
@@ -1,0 +1,23 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: openshift4-nodes
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: openshift4-nodes
+    name: x-app
+    pools.operator.machineconfiguration.openshift.io/app: ''
+  name: x-app
+spec:
+  machineConfigSelector:
+    matchExpressions:
+      - key: machineconfiguration.openshift.io/role
+        operator: In
+        values:
+          - worker
+          - x-app
+          - app
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/app: ''

--- a/tests/golden/cloudscale/openshift4-nodes/openshift4-nodes/machineconfigpool-infra.yaml
+++ b/tests/golden/cloudscale/openshift4-nodes/openshift4-nodes/machineconfigpool-infra.yaml
@@ -1,0 +1,23 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: openshift4-nodes
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: openshift4-nodes
+    name: x-infra
+    pools.operator.machineconfiguration.openshift.io/infra: ''
+  name: x-infra
+spec:
+  machineConfigSelector:
+    matchExpressions:
+      - key: machineconfiguration.openshift.io/role
+        operator: In
+        values:
+          - worker
+          - x-infra
+          - infra
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/infra: ''

--- a/tests/golden/cloudscale/openshift4-nodes/openshift4-nodes/machineconfigpool-storage.yaml
+++ b/tests/golden/cloudscale/openshift4-nodes/openshift4-nodes/machineconfigpool-storage.yaml
@@ -1,0 +1,23 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: openshift4-nodes
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: openshift4-nodes
+    name: x-storage
+    pools.operator.machineconfiguration.openshift.io/storage: ''
+  name: x-storage
+spec:
+  machineConfigSelector:
+    matchExpressions:
+      - key: machineconfiguration.openshift.io/role
+        operator: In
+        values:
+          - worker
+          - x-storage
+          - storage
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/storage: ''

--- a/tests/golden/cloudscale/openshift4-nodes/openshift4-nodes/machineset-infra.yaml
+++ b/tests/golden/cloudscale/openshift4-nodes/openshift4-nodes/machineset-infra.yaml
@@ -1,0 +1,45 @@
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+metadata:
+  annotations: {}
+  labels:
+    machine.openshift.io/cluster-api-cluster: c-green-test-1234
+    name: infra
+  name: infra
+  namespace: openshift-machine-api
+spec:
+  replicas: 4
+  selector:
+    matchLabels:
+      machine.openshift.io/cluster-api-cluster: c-green-test-1234
+      machine.openshift.io/cluster-api-machineset: infra
+  template:
+    metadata:
+      labels:
+        machine.openshift.io/cluster-api-cluster: c-green-test-1234
+        machine.openshift.io/cluster-api-machine-role: infra
+        machine.openshift.io/cluster-api-machine-type: infra
+        machine.openshift.io/cluster-api-machineset: infra
+    spec:
+      metadata:
+        labels:
+          node-role.kubernetes.io/infra: ''
+          node-role.kubernetes.io/worker: ''
+          syn.tools/cluster-id: c-green-test-1234
+      providerSpec:
+        value:
+          antiAffinityKey: infra
+          baseDomain: my.base.domain
+          flavor: plus-16-4
+          image: custom:rhcos-4.17
+          interfaces:
+            - addresses:
+                - subnetUUID: some_subnet_uuid_here
+              type: Private
+          rootVolumeSizeGB: 100
+          test: foo
+          tokenSecret:
+            name: cloudscale-rw-token
+          userDataSecret:
+            name: cloudscale-user-data
+          zone: lpg1

--- a/tests/golden/cloudscale/openshift4-nodes/openshift4-nodes/machineset-worker.yaml
+++ b/tests/golden/cloudscale/openshift4-nodes/openshift4-nodes/machineset-worker.yaml
@@ -1,0 +1,44 @@
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+metadata:
+  annotations: {}
+  labels:
+    machine.openshift.io/cluster-api-cluster: c-green-test-1234
+    name: worker
+  name: worker
+  namespace: openshift-machine-api
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      machine.openshift.io/cluster-api-cluster: c-green-test-1234
+      machine.openshift.io/cluster-api-machineset: worker
+  template:
+    metadata:
+      labels:
+        machine.openshift.io/cluster-api-cluster: c-green-test-1234
+        machine.openshift.io/cluster-api-machine-role: app
+        machine.openshift.io/cluster-api-machine-type: app
+        machine.openshift.io/cluster-api-machineset: worker
+    spec:
+      metadata:
+        labels:
+          node-role.kubernetes.io/app: ''
+          node-role.kubernetes.io/worker: ''
+          syn.tools/cluster-id: c-green-test-1234
+      providerSpec:
+        value:
+          antiAffinityKey: worker
+          baseDomain: my.base.domain
+          flavor: plus-16-4
+          image: custom:rhcos-4.17
+          interfaces:
+            - addresses:
+                - subnetUUID: some_subnet_uuid_here
+              type: Private
+          rootVolumeSizeGB: 100
+          tokenSecret:
+            name: cloudscale-rw-token
+          userDataSecret:
+            name: cloudscale-user-data
+          zone: lpg1


### PR DESCRIPTION
In addition, this PR enables overriding the machineset providerSpec in the hierarchy.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
