### PR TITLE
Allow customizing `.spec.template` in a NodeGroup generated MachineSet

### DIFF
--- a/component/machine-sets.jsonnet
+++ b/component/machine-sets.jsonnet
@@ -59,9 +59,9 @@ local machineSetSpecs = function(name, set, role)
                 antiAffinityKey: name,
               },
             } else {}
-          ) + com.makeMergeable(std.get(set, 'providerSpec', {})),
+          ),
         },
-      },
+      } + com.makeMergeable(std.get(set, 'template', {})),
     },
   };
 
@@ -116,10 +116,10 @@ local cpMachineSetSpecs = function(set)
                   antiAffinityKey: 'master',
                 },
               } else {}
-            ) + com.makeMergeable(std.get(set, 'providerSpec', {})),
+            ),
           },
         },
-      },
+      } + com.makeMergeable(std.get(set, 'template', {})),
     },
   };
 

--- a/tests/cloudscale.yml
+++ b/tests/cloudscale.yml
@@ -42,6 +42,11 @@ parameters:
         replicas: 3
       infra:
         replicas: 4
-        providerSpec:
-          value:
-            test: foo
+        template:
+          spec:
+            metadata:
+              labels:
+                foo: bar
+            providerSpec:
+              value:
+                test: foo

--- a/tests/golden/cloudscale/openshift4-nodes/openshift4-nodes/machineset-infra.yaml
+++ b/tests/golden/cloudscale/openshift4-nodes/openshift4-nodes/machineset-infra.yaml
@@ -23,6 +23,7 @@ spec:
     spec:
       metadata:
         labels:
+          foo: bar
           node-role.kubernetes.io/infra: ''
           node-role.kubernetes.io/worker: ''
           syn.tools/cluster-id: c-green-test-1234


### PR DESCRIPTION
Turns out, for some tenants we add custom labels to the MachineSet template spec, and we need to be able to do this still after switching to the NodeGroup mechanism.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
