### PR TITLE
Fix capacity alerts get duplicated by Espejote

### DIFF
--- a/component/capacity.jsonnet
+++ b/component/capacity.jsonnet
@@ -206,6 +206,9 @@ local exprMap = {
   [if params.capacityAlerts.enabled then 'capacity_alerting_rules']: prom.PrometheusRule('openshift4-nodes-capacity') {
     metadata+: {
       annotations+: defaultAnnotations,
+      labels+: {
+        'espejote.io/ignore': '',
+      },
       namespace: inv.parameters.openshift4_monitoring.namespace,
     },
     spec+: {

--- a/tests/golden/autoscaling/openshift4-nodes/openshift4-nodes/capacity_alerting_rules.yaml
+++ b/tests/golden/autoscaling/openshift4-nodes/openshift4-nodes/capacity_alerting_rules.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     syn_component: openshift4-nodes
   labels:
+    espejote.io/ignore: ''
     name: openshift4-nodes-capacity
   name: openshift4-nodes-capacity
   namespace: foo

--- a/tests/golden/capacity/openshift4-nodes/openshift4-nodes/capacity_alerting_rules.yaml
+++ b/tests/golden/capacity/openshift4-nodes/openshift4-nodes/capacity_alerting_rules.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     syn_component: openshift4-nodes
   labels:
+    espejote.io/ignore: ''
     name: openshift4-nodes-capacity
   name: openshift4-nodes-capacity
   namespace: foo


### PR DESCRIPTION
The capacity alerts are deployed to namespace openshift-monitoring, which leads the ManagedResource in that namespace to duplicate the alerts. This PR labels the deployed PrometheusRule with `espejote.io/ignore`.




## Checklist

- [ ] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [ ] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [ ] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
