### PR TITLE
Fix rendering of `MachineConfig` resources which don't set `spec.config`

### DIFF
--- a/component/machine-configs.jsonnet
+++ b/component/machine-configs.jsonnet
@@ -11,7 +11,8 @@ local params = inv.parameters.openshift4_nodes;
 local mergedConfigs = machineConfigPools.MachineConfigs + com.makeMergeable(params.machineConfigs);
 
 local machineConfigs = [
-  if std.objectHas(mc.spec.config, 'storage') &&
+  if std.objectHas(mc.spec, 'config') &&
+     std.objectHas(mc.spec.config, 'storage') &&
      std.objectHas(mc.spec.config.storage, 'files') then
     local inline_files = std.filter(
       function(f) std.objectHas(f.contents, 'inline'),


### PR DESCRIPTION
For example, `MachineConfig` resources which only set `spec.kernelArgs`.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
